### PR TITLE
Updating package name of foundation-engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A collection of shareable, stateful components that interact with hypermedia API
 
 ```js
 import 'foundation-components/components/activity/name/d2l-activity-name.js';
-import { html } from 'foundation-engine/framework/hypermedia-components.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/hypermedia-components.js';
 import { LitElement } from 'lit-element/lit-element.js';
 
 class MyComponent extends LitElement {

--- a/components/activity-collection/editor/d2l-activity-collection-editor-lp.js
+++ b/components/activity-collection/editor/d2l-activity-collection-editor-lp.js
@@ -1,8 +1,8 @@
 import '@brightspace-ui/core/components/list/list.js';
 import '@brightspace-ui/core/components/list/list-item.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 
 const rels = Object.freeze({
 	collection: 'https://activities.api.brightspace.com/rels/activity-collection',

--- a/components/activity/description/d2l-activity-description-course.js
+++ b/components/activity/description/d2l-activity-description-course.js
@@ -1,7 +1,7 @@
 import '../../common/d2l-hm-description.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
 const rels = Object.freeze({

--- a/components/activity/description/d2l-activity-description-learning-path.js
+++ b/components/activity/description/d2l-activity-description-learning-path.js
@@ -1,7 +1,7 @@
 import '../../common/d2l-hm-description.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
 const rels = Object.freeze({

--- a/components/activity/editor/d2l-activity-editor-availability.js
+++ b/components/activity/editor/d2l-activity-editor-availability.js
@@ -1,5 +1,5 @@
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { LitElement } from 'lit-element/lit-element.js';
 
 const rels = Object.freeze({

--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -1,8 +1,8 @@
 import '@brightspace-ui/core/components/button/button.js';
 import 'd2l-activities/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 
 class ActivityEditorFooter extends HypermediaStateMixin(LitElement) {
 

--- a/components/activity/editor/d2l-activity-editor-header.js
+++ b/components/activity/editor/d2l-activity-editor-header.js
@@ -1,8 +1,8 @@
 import '../description/d2l-activity-description.js';
 import '../name/d2l-activity-name.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 
 class ActivityEditorHeader extends HypermediaStateMixin(LitElement) {
 

--- a/components/activity/editor/d2l-activity-editor-main-assignment.js
+++ b/components/activity/editor/d2l-activity-editor-main-assignment.js
@@ -1,10 +1,10 @@
 import './d2l-activity-editor-name.js';
 import './d2l-activity-editor-score.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LitElement } from 'lit-element/lit-element.js';
-import { observableTypes } from 'foundation-engine/state/sirenComponents/sirenComponentFactory.js';
+import { observableTypes } from '@brightspace-hmc/foundation-engine/state/sirenComponents/sirenComponentFactory.js';
 
 const rels = Object.freeze({
 	assignment: 'https://api.brightspace.com/rels/assignment',

--- a/components/activity/editor/d2l-activity-editor-main-collection.js
+++ b/components/activity/editor/d2l-activity-editor-main-collection.js
@@ -5,8 +5,8 @@ import '@brightspace-ui/core/components/list/list-item.js';
 import '../item/d2l-activity-item.js';
 
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { repeat } from 'lit-html/directives/repeat';
 
 const rels = Object.freeze({

--- a/components/activity/editor/d2l-activity-editor-name.js
+++ b/components/activity/editor/d2l-activity-editor-name.js
@@ -1,8 +1,8 @@
 import '../../common/d2l-hm-name.js';
 import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css,  LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 
 class ActivityEditorName extends HypermediaStateMixin(LitElement) {
 	static get properties() {

--- a/components/activity/editor/d2l-activity-editor-score.js
+++ b/components/activity/editor/d2l-activity-editor-score.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 
 const rels = Object.freeze({

--- a/components/activity/editor/d2l-activity-editor-sidebar-assignment.js
+++ b/components/activity/editor/d2l-activity-editor-sidebar-assignment.js
@@ -1,8 +1,8 @@
 import './d2l-activity-editor-availability.js';
 import './d2l-activity-editor-submission.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 
 const rels = Object.freeze({
 	specialization: 'https://api.brightspace.com/rels/specialization'

--- a/components/activity/editor/d2l-activity-editor-submission.js
+++ b/components/activity/editor/d2l-activity-editor-submission.js
@@ -1,8 +1,8 @@
 import './d2l-activity-editor-type.js';
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import { bodyCompactStyles, bodySmallStyles, heading3Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { LitElement } from 'lit-element/lit-element.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';

--- a/components/activity/editor/d2l-activity-editor-type-assignment.js
+++ b/components/activity/editor/d2l-activity-editor-type-assignment.js
@@ -1,7 +1,7 @@
 import { bodyCompactStyles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';

--- a/components/activity/editor/d2l-activity-editor.js
+++ b/components/activity/editor/d2l-activity-editor.js
@@ -5,7 +5,7 @@ import './d2l-activity-editor-header.js';
 import './d2l-activity-editor-sidebar.js';
 import './d2l-activity-editor-main.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { nothing } from 'lit-html';
 
 class ActivityEditor extends LitElement {

--- a/components/activity/icon/d2l-activity-icon.js
+++ b/components/activity/icon/d2l-activity-icon.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/icons/icon.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { ParentLitMixin } from 'foundation-engine/framework/lit/parent-lit-mixin.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { ParentLitMixin } from '@brightspace-hmc/foundation-engine/framework/lit/parent-lit-mixin.js';
 
 class ActivityIcon extends ParentLitMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {

--- a/components/activity/image/d2l-activity-image-collection.js
+++ b/components/activity/image/d2l-activity-image-collection.js
@@ -1,7 +1,7 @@
 import '../../common/d2l-hm-course-image.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
 const rels = Object.freeze({

--- a/components/activity/image/d2l-activity-image-course.js
+++ b/components/activity/image/d2l-activity-image-course.js
@@ -1,6 +1,6 @@
 import '../../common/d2l-hm-course-image.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { LitElement } from 'lit-element/lit-element.js';
 
 const rels = Object.freeze({

--- a/components/activity/item/d2l-activity-item.js
+++ b/components/activity/item/d2l-activity-item.js
@@ -2,9 +2,9 @@ import '@brightspace-ui/core/components/list/list-item-content.js';
 import '../image/d2l-activity-image.js';
 import '../name/d2l-activity-name.js';
 import '../type/d2l-activity-type.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { guard } from 'lit-html/directives/guard';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { ListItemAccumulatorMixin } from '@brightspace-ui-labs/list-item-accumulator/list-item-accumulator-mixin.js';
 import { LitElement } from 'lit-element/lit-element.js';
 

--- a/components/activity/name/d2l-activity-name-course.js
+++ b/components/activity/name/d2l-activity-name-course.js
@@ -1,7 +1,7 @@
 import '../../common/d2l-hm-name.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 
 const rels = Object.freeze({
 	organization: 'https://api.brightspace.com/rels/organization'

--- a/components/activity/name/d2l-activity-name-learning-path.js
+++ b/components/activity/name/d2l-activity-name-learning-path.js
@@ -1,8 +1,8 @@
 import '../../common/d2l-hm-name.js';
 import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from 'foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
 
 const rels = Object.freeze({

--- a/components/activity/type/d2l-activity-type.js
+++ b/components/activity/type/d2l-activity-type.js
@@ -1,5 +1,5 @@
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { LitElement } from 'lit-element/lit-element.js';
 
 class ActivityType extends HypermediaStateMixin(LitElement) {

--- a/components/common/d2l-hm-course-image.js
+++ b/components/common/d2l-hm-course-image.js
@@ -1,7 +1,7 @@
 import 'd2l-course-image/d2l-course-image.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 
 const rels = Object.freeze({
 	courseImage: 'https://api.brightspace.com/rels/organization-image'

--- a/components/common/d2l-hm-description.js
+++ b/components/common/d2l-hm-description.js
@@ -1,6 +1,6 @@
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { HypermediaStateMixin, observableTypes} from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes} from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 
 class HmDescription extends HypermediaStateMixin(LitElement) {
 	static get properties() {

--- a/components/common/d2l-hm-name.js
+++ b/components/common/d2l-hm-name.js
@@ -1,6 +1,6 @@
 import { css, LitElement } from 'lit-element/lit-element.js';
-import { HypermediaStateMixin, observableTypes } from 'foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { html } from 'foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 
 class HmName extends HypermediaStateMixin(LitElement) {
 	static get properties() {

--- a/creating-new-components.md
+++ b/creating-new-components.md
@@ -5,8 +5,8 @@ If your tool needs to interact with hypermedia entities in a way that isn't avai
 ## Basic Setup
 
 ```js
-import { customHypermediaElement, html } from 'foundation-engine/framework/hypermedia-components.js';
-import { HypermediaStateMixin } from 'foundation-engine/framework/hypermedia-lit-mixin.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/hypermedia-components.js';
+import { HypermediaStateMixin } from '@brightspace-hmc/foundation-engine/framework/hypermedia-lit-mixin.js';
 import { LitElement } from 'lit-element/lit-element.js';
 
 class CustomComponent extends HypermediaStateMixin(LitElement) {
@@ -74,7 +74,7 @@ import './d2l-activity-editor-main-custom.js';
 Often, your component will want to observe specific information about an entity. We can do this by adding observable properties to the component.
 
 ```js
-import { observableTypes } from 'foundation-engine/framework/hypermedia-lit-mixin.js';
+import { observableTypes } from '@brightspace-hmc/foundation-engine/framework/hypermedia-lit-mixin.js';
 ...
 
 static get properties() {
@@ -158,7 +158,7 @@ static get properties() {
 Many components will need to alter the state of their entity. Let's see how performing an `update` action might work.
 
 ```js
-import { observableTypes } from 'foundation-engine/framework/hypermedia-lit-mixin.js';
+import { observableTypes } from '@brightspace-hmc/foundation-engine/framework/hypermedia-lit-mixin.js';
 ...
 
 static get properties() {


### PR DESCRIPTION
- Names are finalized - `foundation-engine` has become `@brightspace-hmc/foundation-engine`
- Should fix the broken build
- We should add semantic versioning to `foundation-engine` as a side note to make major changes like this easier. I did this the dumb way.