### PR TITLE
Fixing demo path to d2l-activity-editor.js file

### DIFF
--- a/demo/d2l-activity-editor.html
+++ b/demo/d2l-activity-editor.html
@@ -5,7 +5,7 @@
 		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
-			import '../components/activity/editor/d2l-activity-editor.js';
+			import '../components/activity/editor/d2l-hc-activity-editor.js';
 		</script>
 		<title>d2l-polaris</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
I noticed that the demo did not appear to be loading the activity editor, determined it was due to a path error. This should fix it up.