### PR TITLE
Fix typo in repo url for github actions release

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Stateful and dynamically resolved hypermedia components for Brightspace",
   "repository": {
     "type": "git",
-    "url": "https://github.com/BrightspaceHypermediaComponent/foundation-components.git"
+    "url": "https://github.com/BrightspaceHypermediaComponents/foundation-components.git"
   },
   "version": "0.0.3",
   "scripts": {


### PR DESCRIPTION
Hoping this typo is the cause of [this release error](https://github.com/BrightspaceHypermediaComponents/foundation-components/runs/1475977329).