### PR TITLE
test: Add testing coverage

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "brightspace/lit-config"
+  "extends": "brightspace/lit-config",
+  "ignorePatterns": ["coverage/**/*"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 package-lock.json
 test/screenshots/current/
 test/screenshots/golden/
+.nyc_output
+coverage/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,17 @@ module.exports = config => {
 				// if you are using 'bare module imports' you will need this option
 				nodeResolve: true,
 			},
+			coverageIstanbulReporter: {
+				thresholds: {
+					// don't prevent tests from failing if we have bad coverage
+					global: {
+						statements: 0,
+						lines: 0,
+						branches: 0,
+						functions: 0,
+					},
+				},
+			},
 		}),
 	);
 	return config;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:diff": "mocha ./**/*.visual-diff.js -t 40000",
     "test:diff:golden": "mocha ./**/*.visual-diff.js -t 40000 --golden",
     "test:diff:golden:commit": "commit-goldens",
-    "test:headless": "karma start",
+    "test:headless": "karma start --coverage",
     "test:sauce": "karma start karma.sauce.conf.js"
   },
   "author": "D2L Corporation",


### PR DESCRIPTION
## Context
[US121576](https://rally1.rallydev.com/#/detail/userstory/447027030140?fdp=true)
We have basically nonexistent coverage right now, but that's fine! Now we can look at it in all of its ugly glory!!!1
Related to https://github.com/BrightspaceHypermediaComponents/foundation-engine/pull/26

<img width="569" alt="Screen Shot 2020-12-01 at 2 29 13 PM" src="https://user-images.githubusercontent.com/2412740/100789096-fb33c980-33e3-11eb-96d2-904ac2dc7e09.png">
