### PR TITLE
Add activity description editor component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '12'
       - name: Install dependencies
         run: npm install
       - name: Lint (JavaScript)

--- a/components/activity/description/README.md
+++ b/components/activity/description/README.md
@@ -2,6 +2,17 @@
 
 Shows a description of an activity. **Currently does not have a default.**
 
+# d2l-activity-description-editor
+
+Provides a textarea for editing activitity descriptions. Updates to the
+textarea are only reflected in the state and are not saved until the state
+has been pushed.
+
+## Example
+```html
+<d2l-activity-description-editor href="${this.href}" .token="${this.token}"></d2l-activity-description-editor>
+```
+
 ## Custom
 
 ### `d2l-activity-description-course`

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -14,8 +14,7 @@ class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 
 	static get properties() {
 		return {
-			description: { type: String, observable: observableTypes.property, route: [{observable: observableTypes.link, rel: rels.specialization}],
-				hasChanged: () => true},
+			description: { type: String, observable: observableTypes.property, route: [{observable: observableTypes.link, rel: rels.specialization}]},
 			updateDescription: { type: Object, observable: observableTypes.action, name: 'update-description',
 				route: [{observable: observableTypes.link, rel: rels.specialization}]
 			}

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -11,9 +11,11 @@ const rels = Object.freeze({
 });
 
 class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
+
 	static get properties() {
 		return {
-			description: { type: String, observable: observableTypes.property, route: [{observable: observableTypes.link, rel: rels.specialization}] },
+			description: { type: String, observable: observableTypes.property, route: [{observable: observableTypes.link, rel: rels.specialization}],
+				hasChanged: () => true},
 			updateDescription: { type: Object, observable: observableTypes.action, name: 'update-description',
 				route: [{observable: observableTypes.link, rel: rels.specialization}]
 			}
@@ -43,8 +45,8 @@ class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 			<textarea class="d2l-input"
 				@input="${this._onInputDescription}"
 				placeholder="Write a description"
-				value="${this.description ? this.description : ''}"
-			></textarea>
+				.value="${this.description}"
+			>${this.description ? this.description : ''}</textarea>
 		</label>
 		` : null;
 	}

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -26,12 +26,12 @@ class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 		return [ inputLabelStyles, inputStyles,
 			css`
 			@media (max-width: 615px) {
-				textarea.d2l-input {
-					height: 100px;
+				.d2l-activity-description-editor textarea {
+					height: 5rem;
 				}
 			}
 
-			textarea.d2l-input {
+			.d2l-activity-description-editor textarea {
 				resize: none;
 			}
 			`
@@ -39,8 +39,8 @@ class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 	}
 
 	render() {
-		return this.updateDescription.has ? html`
-		<label>
+		return this._hasAction('updateDescription') ? html`
+		<label class="d2l-activity-description-editor">
 			<span class="d2l-input-label">Description</span>
 			<textarea class="d2l-input"
 				@input="${this._onInputDescription}"
@@ -52,11 +52,10 @@ class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 	}
 
 	_onInputDescription(e) {
-		if (this.updateDescription.has) {
+		if (this._hasAction('updateDescription')) {
 			this.updateDescription.commit({description: { observable: observableTypes.property, value: e.target.value} });
 		}
 	}
-
 }
 
 customHypermediaElement('d2l-activity-description-editor', ActivityDescriptionEditor);

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -1,0 +1,41 @@
+import '../../common/d2l-hc-description.js';
+import '@brightspace-ui/core/components/inputs/input-text.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { LitElement } from 'lit-element/lit-element.js';
+
+const rels = Object.freeze({
+	specialization: 'https://api.brightspace.com/rels/specialization'
+});
+
+class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
+	static get properties() {
+		return {
+			description: { type: String, observable: observableTypes.property },
+			updateDescription: { type: Object, observable: observableTypes.action, name: 'update-description',
+				route: [{observable: observableTypes.link, rel: rels.specialization}]
+			}
+		};
+	}
+
+	render() {
+		return this.updateDescription.has ? html`
+			<d2l-input-text
+				@input="${this._onInputDescription}"
+				label="Description"
+				placeholder="Enter a description"
+				value="${this.description ? this.description : ''}"
+			></d2l-input-text>
+		` : null;
+	}
+
+	_onInputDescription(e) {
+		if (this.updateDescription.has) {
+			console.log('input description');
+			this.updateDescription.commit({description: { observable: observableTypes.property, value: e.target.value} });
+		}
+	}
+
+}
+
+customHypermediaElement('d2l-activity-description-editor', ActivityDescriptionEditor);

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -1,8 +1,10 @@
 import '../../common/d2l-hc-description.js';
 import '@brightspace-ui/core/components/inputs/input-text.js';
+import { css, LitElement } from 'lit-element/lit-element.js';
 import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { LitElement } from 'lit-element/lit-element.js';
+import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
+import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 
 const rels = Object.freeze({
 	specialization: 'https://api.brightspace.com/rels/specialization'
@@ -18,14 +20,32 @@ class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 		};
 	}
 
+	static get styles() {
+		return [ inputLabelStyles, inputStyles,
+			css`
+			@media (max-width: 615px) {
+				textarea.d2l-input {
+					height: 100px;
+				}
+			}
+
+			textarea.d2l-input {
+				resize: none;
+			}
+			`
+		];
+	}
+
 	render() {
 		return this.updateDescription.has ? html`
-			<d2l-input-text
+		<label>
+			<span class="d2l-input-label">Description</span>
+			<textarea class="d2l-input"
 				@input="${this._onInputDescription}"
-				label="Description"
-				placeholder="Enter a description"
+				placeholder="Write a description"
 				value="${this.description ? this.description : ''}"
-			></d2l-input-text>
+			></textarea>
+		</label>
 		` : null;
 	}
 

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -11,7 +11,7 @@ const rels = Object.freeze({
 class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 	static get properties() {
 		return {
-			description: { type: String, observable: observableTypes.property },
+			description: { type: String, observable: observableTypes.property, route: [{observable: observableTypes.link, rel: rels.specialization}] },
 			updateDescription: { type: Object, observable: observableTypes.action, name: 'update-description',
 				route: [{observable: observableTypes.link, rel: rels.specialization}]
 			}
@@ -31,7 +31,6 @@ class ActivityDescriptionEditor extends HypermediaStateMixin(LitElement) {
 
 	_onInputDescription(e) {
 		if (this.updateDescription.has) {
-			console.log('input description');
 			this.updateDescription.commit({description: { observable: observableTypes.property, value: e.target.value} });
 		}
 	}

--- a/components/activity/editor/d2l-activity-editor-header.js
+++ b/components/activity/editor/d2l-activity-editor-header.js
@@ -1,4 +1,4 @@
-import '../description/d2l-activity-description.js';
+import '../description/d2l-activity-description-editor.js';
 import '../name/d2l-activity-name.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
@@ -35,7 +35,7 @@ class ActivityEditorHeader extends HypermediaStateMixin(LitElement) {
 			<h1 class="d2l-heading-1">
 				<d2l-activity-name href="${this.href}" .token="${this.token}"></d2l-activity-name>
 			</h1>
-			<d2l-activity-description href="${this.href}" .token="${this.token}"></d2l-activity-description>
+			<d2l-activity-description-editor href="${this.href}" .token="${this.token}"></d2l-activity-description-editor>
 		`;
 	}
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,11 @@ const merge = require('deepmerge');
 module.exports = config => {
 	config.set(
 		merge(createDefaultConfig(config), {
+			client: {
+				mocha: {
+					timeout : 6000 // 6 seconds - upped from 2 seconds
+				}
+			},
 			files: [
 				// runs all files ending with .test in the test folder,
 				// can be overwritten by passing a --grep flag. examples:

--- a/karma.sauce.conf.js
+++ b/karma.sauce.conf.js
@@ -47,7 +47,7 @@ module.exports = config => {
 			customLaunchers: customLaunchers,
 			browsers: Object.keys(customLaunchers),
 			reporters: ['dots', 'saucelabs'],
-			singleRun: true
+			singleRun: true,
 		}),
 	);
 	return config;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "fetch-mock": "^9.11.0",
     "karma-sauce-launcher": "^2",
     "lit-analyzer": "^1",
-    "puppeteer": "^1"
+    "puppeteer": "^1",
+    "sinon": "^9.2.1"
   },
   "dependencies": {
     "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-html": "^6",
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
+    "fetch-mock": "^9.11.0",
     "karma-sauce-launcher": "^2",
     "lit-analyzer": "^1",
     "puppeteer": "^1"

--- a/test/activity/description/d2l-activity-description-editor.test.js
+++ b/test/activity/description/d2l-activity-description-editor.test.js
@@ -1,0 +1,136 @@
+import '../../../components/activity/description/d2l-activity-description-editor.js';
+import { assert, elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { learningPathExisting, learningPathNew, learningPathUpdated } from '../../data.js';
+import { mockLink } from '../../fetchMocks.js';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+// use the learningPathUpdated description as the text when updating textareas
+const updatedDescriptionText = learningPathUpdated.properties.description;
+
+async function _createComponentAndWait(path)
+{
+	const element = await fixture(html`<d2l-activity-description-editor href="${path}" token="test-token"></d2l-activity-description-editor>`);
+	await _elementUpdated(element);
+	return element;
+}
+
+// using a delay to wait for fetchMock to be called
+// would prefer a better way
+async function _elementUpdated(element) {
+	return _delay(100).then(async() => {
+		return elementUpdated(element);
+	});
+}
+
+async function _delay(timeMs)
+{
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve();
+		}, timeMs);
+	});
+}
+
+describe('d2l-activity-description-editor', () => {
+
+	describe('constructor', () => {
+
+		it('should construct', () => {
+			runConstructor('d2l-activity-description-editor');
+		});
+	});
+
+	describe('Component', () => {
+		it('should initialize using defined path and expected values', async() => {
+			const element = await _createComponentAndWait('/learning-path/new');
+
+			// paths should be followed
+			assert.isTrue(mockLink.called('path:/learning-path/new'), '/learing-path/new was not called');
+			assert.isTrue(mockLink.called('path:/learning-path/new/object'), '/learing-path/new/object was not called');
+
+			const textarea = element.shadowRoot.querySelector('label textarea');
+
+			// classes are set
+			expect(element.shadowRoot.querySelector('label'))
+				.to.have.class('d2l-activity-description-editor', 'Label should have d2l-activity-description-editor class');
+			expect(element.shadowRoot.querySelector('label span'))
+				.to.have.class('d2l-input-label', 'span should have d2l-input-label class');
+			expect(textarea)
+				.to.have.class('d2l-input', 'textarea should have d2l-input class');
+
+			// verify textarea element
+			assert.equal(textarea.getAttribute('placeholder'), 'Write a description', 'Placeholder text does not match');
+			assert.equal(textarea.value, learningPathNew.properties.description, 'textarea value does not match');
+
+			assert.equal(element.description, learningPathNew.properties.description, 'description property should match');
+		});
+
+		it('description should be set when one is provided', async() => {
+			const element = await _createComponentAndWait('/learning-path/existing');
+
+			// new path should be followed
+			assert.isTrue(mockLink.called('path:/learning-path/existing'), '/learing-path/exiting was not called');
+			assert.isTrue(mockLink.called('path:/learning-path/existing/object'), '/learning-path/existing/object was not called');
+
+			assert.equal(element.shadowRoot.querySelector('label textarea').value,
+				learningPathExisting.properties.description, 'textarea value does not match');
+
+			assert.equal(element.description, learningPathExisting.properties.description, 'description property should match');
+		});
+
+		it('updating should commit state, but not save it', async() => {
+			const element = await _createComponentAndWait('/learning-path/existing');
+			assert.equal(element.description, learningPathExisting.properties.description, 'description should match response');
+
+			const textarea = element.shadowRoot.querySelector('label textarea');
+			textarea.value = updatedDescriptionText;
+			const inputEvent = new Event('input');
+			textarea.dispatchEvent(inputEvent);
+			assert.equal(element.description, learningPathExisting.properties.description, 'description should not be updated after event');
+
+			// does this happen after a commit?
+			await _elementUpdated(element);
+			assert.equal(element.description, learningPathExisting.properties.description, 'description should not be updated when element updates');
+		});
+
+		/* 	These are out of scope, but provided basic mock up for save / cancel
+		*	Still need to figure out how to wait for element to be updated after push / reset
+		*/
+		it('pushing state should save description', async() => {
+			const element = await _createComponentAndWait('/learning-path/existing');
+
+			let textarea = element.shadowRoot.querySelector('label textarea');
+			textarea.value = updatedDescriptionText;
+			const inputEvent = new Event('input');
+			textarea.dispatchEvent(inputEvent);
+			assert.equal(element.description, learningPathExisting.properties.description, 'description should not be updated after event');
+
+			await element._state.push();
+			await _elementUpdated(element);
+			// update fetch should have been called
+			assert.isTrue(mockLink.called('path:/description/update'));
+
+			assert.equal(element.description, updatedDescriptionText, 'description should be updated after a push');
+			textarea = element.shadowRoot.querySelector('label textarea');
+			assert.equal(textarea.value, updatedDescriptionText, 'textarea value should be updated');
+		});
+
+		it('reset state should revert text', async() => {
+			const element = await _createComponentAndWait('/learning-path/existing');
+
+			let textarea = element.shadowRoot.querySelector('label textarea');
+			textarea.value = updatedDescriptionText;
+			const inputEvent = new Event('input');
+			textarea.dispatchEvent(inputEvent);
+
+			// figure out how to call reset()
+			element._state.reset();
+			await _elementUpdated(element);
+			assert.equal(element.description, learningPathExisting.properties.description, 'description should not have changed');
+
+			textarea = element.shadowRoot.querySelector('label textarea');
+			assert.equal(textarea.value, learningPathExisting.properties.description, 'textarea value should be reset');
+		});
+	});
+
+});

--- a/test/activity/description/d2l-activity-description-editor.test.js
+++ b/test/activity/description/d2l-activity-description-editor.test.js
@@ -128,6 +128,8 @@ describe('d2l-activity-description-editor', () => {
 			console.log(textarea);
 			assert.equal(element.description, updatedDescriptionText, 'description should be updated');
 
+			await aTimeout(1000);
+
 			console.log(textarea);
 
 			const spy = sinon.spy(element);

--- a/test/activity/description/d2l-activity-description-editor.test.js
+++ b/test/activity/description/d2l-activity-description-editor.test.js
@@ -120,21 +120,16 @@ describe('d2l-activity-description-editor', () => {
 			const element = await _createComponentAndWait('/learning-path/existing');
 
 			const textarea = element.shadowRoot.querySelector('label textarea');
-			console.log(textarea);
 			textarea.value = updatedDescriptionText;
 			const inputEvent = new Event('input');
 			textarea.dispatchEvent(inputEvent);
 
-			console.log(textarea);
 			assert.equal(element.description, updatedDescriptionText, 'description should be updated');
 
 			await aTimeout(1000);
 
-			console.log(textarea);
-
 			const spy = sinon.spy(element);
 			element._state.reset();
-			console.log(textarea);
 			await aTimeout(100);
 			await _elementUpdated(element);
 			assert.equal(element.description, learningPathExisting.properties.description, 'description should be reset');
@@ -142,8 +137,6 @@ describe('d2l-activity-description-editor', () => {
 			assert.isTrue(spy.render.called);
 
 			const textarea2 = element.shadowRoot.querySelector('label textarea');
-			console.log(textarea2);
-			console.log(textarea2.value);
 			assert.equal(textarea2.value, learningPathExisting.properties.description, 'textarea value should be reset');
 		});
 	});

--- a/test/activity/description/d2l-activity-description-editor.test.js
+++ b/test/activity/description/d2l-activity-description-editor.test.js
@@ -11,14 +11,14 @@ const updatedDescriptionText = learningPathUpdated.properties.description;
 async function _createComponentAndWait(path)
 {
 	const element = await fixture(html`<d2l-activity-description-editor href="${path}" token="test-token"></d2l-activity-description-editor>`);
-	await _elementUpdated(element);
+	await _elementUpdated(element, 100);
 	return element;
 }
 
 // using a delay to wait for fetchMock to be called
 // would prefer a better way
-async function _elementUpdated(element) {
-	return aTimeout(100).then(async() => {
+async function _elementUpdated(element, delayMs) {
+	return aTimeout(delayMs).then(async() => {
 		await elementUpdated(element);
 	});
 }
@@ -104,8 +104,7 @@ describe('d2l-activity-description-editor', () => {
 
 			const spy = sinon.spy(element);
 			element._state.push();
-			await aTimeout(100);
-			await _elementUpdated(element);
+			await _elementUpdated(element, 200);
 
 			assert.isTrue(mockLink.called('path:/description/update'));
 
@@ -130,8 +129,7 @@ describe('d2l-activity-description-editor', () => {
 
 			const spy = sinon.spy(element);
 			element._state.reset();
-			await aTimeout(100);
-			await _elementUpdated(element);
+			await _elementUpdated(element, 200);
 			assert.equal(element.description, learningPathExisting.properties.description, 'description should be reset');
 
 			assert.isTrue(spy.render.called);

--- a/test/activity/description/d2l-activity-description-editor.test.js
+++ b/test/activity/description/d2l-activity-description-editor.test.js
@@ -11,13 +11,13 @@ const updatedDescriptionText = learningPathUpdated.properties.description;
 async function _createComponentAndWait(path)
 {
 	const element = await fixture(html`<d2l-activity-description-editor href="${path}" token="test-token"></d2l-activity-description-editor>`);
-	await _delayAndWaitForElement(element, 100);
+	await _delayAndAwaitForElement(element, 100);
 	return element;
 }
 
 // using a delay to wait for fetchMock to be called
 // would prefer a better way
-async function _delayAndWaitForElement(element, delayMs) {
+async function _delayAndAwaitForElement(element, delayMs) {
 	return aTimeout(delayMs).then(async() => {
 		await elementUpdated(element);
 	});
@@ -92,7 +92,7 @@ describe('d2l-activity-description-editor', () => {
 				assert.equal(element.description, learningPathExisting.properties.description, 'description property should match');
 			});
 
-			it('updating should commit state, but not save it', async() => {
+			it('updating should commit state', async() => {
 				const spy = sinon.spy(element.updateDescription);
 				await fireTextareaInputEvent(element);
 
@@ -107,7 +107,7 @@ describe('d2l-activity-description-editor', () => {
 				await fireTextareaInputEvent(element);
 
 				element._state.push();
-				await _delayAndWaitForElement(element, 100);
+				await _delayAndAwaitForElement(element, 100);
 
 				assert.isTrue(mockLink.called('path:/description/update'), 'Updated path was not called');
 				assert.equal(element.description, updatedDescriptionText, 'description should be updated after a push');

--- a/test/activity/description/d2l-activity-description.test.js
+++ b/test/activity/description/d2l-activity-description.test.js
@@ -1,0 +1,17 @@
+import '../../../components/activity/description/d2l-activity-description.js';
+// import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
+
+describe('d2l-activity-description', () => {
+
+	describe('constructor', () => {
+
+		it('should construct d2l-activity-description-learning-path', () => {
+			runConstructor('d2l-activity-description-learning-path');
+		});
+
+		it('should construct d2l-activity-description-course', () => {
+			runConstructor('d2l-activity-description-course');
+		});
+	});
+});

--- a/test/data.js
+++ b/test/data.js
@@ -1,0 +1,77 @@
+export const learningPathExisting = {
+	class: ['named-entity', 'describable-entity', 'draft-published-entity', 'published', 'active', 'learning-path'],
+	properties: {
+		'name':'[object Object]',
+		'code':'LP',
+		'startDate':null,
+		'endDate':null,
+		'isActive':true,
+		'description':'description of my LP'
+	},
+	entities: [
+		{'class':['richtext',  'description'],  'rel':['item'], 'properties':{'text':'description of my LP', 'html':'description of my LP'}},
+		{'class':['color'],  'rel':['https://api.brightspace.com/rels/color'],  'properties':{'hexString':'#2f5e00',  'description':''}},
+		{'class':['course-image'],  'rel':['https://api.brightspace.com/rels/organization-image',  'nofollow'],  'href':'/images/123456'},
+		{'class':['relative-uri'],  'rel':['item',  'https://api.brightspace.com/rels/organization-homepage'],  'properties':{'path':'/learningpaths/123231/View'}}
+	],
+	actions: [
+		{'href':'/update/name',  'name':'update-name',  'method':'PATCH',  'fields':[{'class':['required'],  'type':'text',  'name':'name',  'value':'[object Object]'}]},
+		{'href':'/description/update',  'name':'update-description',  'method':'PATCH',  'fields':[{'class':['required'],  'type':'text',  'name':'description',  'value':'description of my LP'}]},
+		{'href':'/update/draft',  'name':'update-draft',  'method':'PATCH',  'fields':[{'type':'checkbox',  'name':'draft',  'value':false}]},
+		{'href':'/set/catalog/image',  'name':'set-catalog-image',  'method':'POST',  'fields':[{'type':'text',  'name':'imagePath',  'value':''}]},
+		{'href':'/remove/homepage/banner',  'name':'remove-homepage-banner',  'method':'PUT',  'fields':[{'type':'hidden',  'name':'showCourseBanner',  'value':false}]},
+		{'href':'/delete/item',  'name':'delete',  'method':'DELETE'}
+	]
+};
+
+export const learningPathUpdated = {
+	class: ['named-entity', 'describable-entity', 'draft-published-entity', 'published', 'active', 'learning-path'],
+	properties: {
+		'name':'updated name',
+		'code':'LP',
+		'startDate':null,
+		'endDate':null,
+		'isActive':true,
+		'description': 'updated description'
+	},
+	entities: [
+		{'class':['richtext',  'description'],  'rel':['item'], 'properties':{'text':'description of my LP', 'html':'description of my LP'}},
+		{'class':['color'],  'rel':['https://api.brightspace.com/rels/color'],  'properties':{'hexString':'#2f5e00',  'description':''}},
+		{'class':['course-image'],  'rel':['https://api.brightspace.com/rels/organization-image',  'nofollow'],  'href':'/images/123456'},
+		{'class':['relative-uri'],  'rel':['item',  'https://api.brightspace.com/rels/organization-homepage'],  'properties':{'path':'/learningpaths/123456/View'}}
+	],
+	actions: [
+		{'href':'/update/name',  'name':'update-name',  'method':'PATCH',  'fields':[{'class':['required'],  'type':'text',  'name':'name',  'value':'[object Object]'}]},
+		{'href':'/description/update',  'name':'update-description',  'method':'PATCH',  'fields':[{'class':['required'],  'type':'text',  'name':'description',  'value':'description of my LP'}]},
+		{'href':'/update/draft',  'name':'update-draft',  'method':'PATCH',  'fields':[{'type':'checkbox',  'name':'draft',  'value':false}]},
+		{'href':'/set/catalog/image',  'name':'set-catalog-image',  'method':'POST',  'fields':[{'type':'text',  'name':'imagePath',  'value':''}]},
+		{'href':'/remove/homepage/banner',  'name':'remove-homepage-banner',  'method':'PUT',  'fields':[{'type':'hidden',  'name':'showCourseBanner',  'value':false}]},
+		{'href':'/delete/item',  'name':'delete',  'method':'DELETE'}
+	]
+};
+
+export const learningPathNew = {
+	class: ['named-entity', 'describable-entity', 'draft-published-entity', 'published', 'active', 'learning-path'],
+	properties: {
+		'name':'',
+		'code':'LP',
+		'startDate':null,
+		'endDate':null,
+		'isActive':true,
+		'description':''
+	},
+	entities: [
+		{'class':['richtext',  'description'],  'rel':['item'], 'properties':{'text':'', 'html':''}},
+		{'class':['color'],  'rel':['https://api.brightspace.com/rels/color'],  'properties':{'hexString':'#2f5e00',  'description':''}},
+		{'class':['course-image'],  'rel':['https://api.brightspace.com/rels/organization-image',  'nofollow'],  'href':'/images/123456'},
+		{'class':['relative-uri'],  'rel':['item',  'https://api.brightspace.com/rels/organization-homepage'],  'properties':{'path':'/learningpaths/123456/View'}}
+	],
+	actions: [
+		{'href':'/update/name',  'name':'update-name',  'method':'PATCH',  'fields':[{'class':['required'],  'type':'text',  'name':'name',  'value':'[object Object]'}]},
+		{'href':'/description/update',  'name':'update-description',  'method':'PATCH',  'fields':[{'class':['required'],  'type':'text',  'name':'description',  'value':'description of my LP'}]},
+		{'href':'/update/draft',  'name':'update-draft',  'method':'PATCH',  'fields':[{'type':'checkbox',  'name':'draft',  'value':false}]},
+		{'href':'/set/catalog/image',  'name':'set-catalog-image',  'method':'POST',  'fields':[{'type':'text',  'name':'imagePath',  'value':''}]},
+		{'href':'/remove/homepage/banner',  'name':'remove-homepage-banner',  'method':'PUT',  'fields':[{'type':'hidden',  'name':'showCourseBanner',  'value':false}]},
+		{'href':'/delete/item',  'name':'delete',  'method':'DELETE'}
+	]
+};

--- a/test/fetchMocks.js
+++ b/test/fetchMocks.js
@@ -1,0 +1,38 @@
+import { learningPathExisting, learningPathNew, learningPathUpdated } from './data.js';
+import fetchMock from 'fetch-mock/esm/client.js';
+
+/*
+	HMC engine makes a call to the Component link and then fetches the href to get the object.
+	Method handles this interaction by supplying the desired endpoint.
+	(ex. comp with href="/learning-path/new" creates a link to /learning-path/new/object)
+*/
+function GenerateComponentLink(linkPath) {
+	return {
+		links:[
+			{
+				href: linkPath,
+				rel: ['https://api.brightspace.com/rels/organization', 'https://api.brightspace.com/rels/specialization']
+			}
+		]
+	};
+}
+
+export const mockLink = fetchMock.mock('path:/learning-path/new', () => {
+	return GenerateComponentLink('/learning-path/new/object');
+})
+	.mock('path:/learning-path/new/object', () => {
+		return learningPathNew;
+	})
+	.mock('path:/learning-path/existing', () => {
+		console.log('called /lp/e/');
+		return GenerateComponentLink('/learning-path/existing/object');
+	})
+
+	.mock('path:/learning-path/existing/object', () => {
+		console.log('called /lp/e/o');
+		return learningPathExisting;
+	})
+	.mock('path:/description/update', () => {
+		console.log('called /d/u');
+		return learningPathUpdated;
+	});

--- a/test/fetchMocks.js
+++ b/test/fetchMocks.js
@@ -24,15 +24,12 @@ export const mockLink = fetchMock.mock('path:/learning-path/new', () => {
 		return learningPathNew;
 	})
 	.mock('path:/learning-path/existing', () => {
-		console.log('called /lp/e/');
 		return GenerateComponentLink('/learning-path/existing/object');
 	})
 
 	.mock('path:/learning-path/existing/object', () => {
-		console.log('called /lp/e/o');
 		return learningPathExisting;
 	})
 	.mock('path:/description/update', () => {
-		console.log('called /d/u');
 		return learningPathUpdated;
 	});


### PR DESCRIPTION
```Context```
https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F378718811140

Created d2l-activity-description-editor component which adds a textarea that can be save / cancelled. Clicking save updates the description, while cancelling reverts it back to the previous state.

```Quality```
manual testing to ensure cancel / save works as expected 
Textarea should also appear larger when on smaller screens as per images in the rally story.