### PR TITLE
feat: updating collection editor to use sub entity objects

### DIFF
--- a/components/activity/editor/collection/d2l-activity-editor-main-collection.js
+++ b/components/activity/editor/collection/d2l-activity-editor-main-collection.js
@@ -65,7 +65,7 @@ class ActivityEditorMainCollection extends HypermediaStateMixin(LitElement) {
 				</div>
 				<div class="d2l-activity-collection-activities">
 					<d2l-list @d2l-list-item-position-change="${this._moveItems}">
-						${repeat(this.items, href => href, href => html`<d2l-activity-list-item href="${href}" .token="${this.token}" draggable key="${href}"></d2l-activity-list-item>`)}
+						${repeat(this.items, item => item.href, item => html`<d2l-activity-list-item href="${item.href}" .token="${this.token}" draggable key="${item.properties.id}"></d2l-activity-list-item>`)}
 					</d2l-list>
 				</div>
 			</div>
@@ -73,7 +73,7 @@ class ActivityEditorMainCollection extends HypermediaStateMixin(LitElement) {
 	}
 
 	_moveItems(e) {
-		e.detail.reorder(this.items, { keyFn: (item) => item });
+		e.detail.reorder(this.items, { keyFn: (item) => item.properties.id });
 		this.requestUpdate('items', []);
 	}
 }

--- a/creating-new-components.md
+++ b/creating-new-components.md
@@ -103,7 +103,7 @@ render() {
 Types are based on Siren's hypermedia format.
 
 - `classes`: classes on the entity
-- `entity`: a dump of the entire entity object associated with this href
+- `entity`: the entire parsed entity object associated with this href
 - `link`: a string representing a link
 - `property`: a simple property that's part of the entity
 - `subEntity`: a parsed siren sub entity object

--- a/creating-new-components.md
+++ b/creating-new-components.md
@@ -103,10 +103,11 @@ render() {
 Types are based on Siren's hypermedia format.
 
 - `classes`: classes on the entity
-- `entity`: an entity that's relevant to this entity, such as a course image
+- `entity`: a dump of the entire entity object associated with this href
 - `link`: a string representing a link
 - `property`: a simple property that's part of the entity
-- `subEntities`: sub entities that are attached to the entity, such as an array of activities
+- `subEntity`: a parsed siren sub entity object
+- `subEntities`: an array of parsed siren sub entities with the same `rel`
 
 ### Routing
 


### PR DESCRIPTION
## Context
[US122956](https://rally1.rallydev.com/#/detail/userstory/460074259704?fdp=true)
Hooks up the `d2l-activity-editor-main-collection` component to support the new `subEntities` change. Other `subEntities` and `subEntity` types use routing for existing components, and the change does not affect them.