### PR TITLE
feat: cancel LP redirects to admin view

### DIFF
--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -1,11 +1,17 @@
 import '@brightspace-ui/core/components/button/button.js';
 import 'd2l-activities/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
-import { HypermediaStateMixin } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { LocalizeFoundationEditor } from './lang/localization.js';
 
 class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin(LitElement)) {
+
+	static get properties() {
+		return {
+			up: { type: Object, observable: observableTypes.link, rel: 'up'}
+		};
+	}
 
 	static get styles() {
 		return [css`
@@ -38,6 +44,10 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 
 	_onCancelClick() {
 		this._state.reset();
+
+		if (this.up) {
+			window.location.href = this.up;
+		}
 	}
 }
 


### PR DESCRIPTION
[US123696](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F478919016876)

```Context```
Cancel button should redirect to the learning paths admin page. The link to the redirect page should be added the hypermedia response with the rel "up".

```Quality```
tested with local LMS (the lms code has not been merged yet) with BSI. When clicking cancel the window is redirected to d2l/le/learningpaths/admin/view

using polarisdev (no up link in links), clicking cancel does not redirect and no errors are present in the console. This is expected behavior

*Holding off on unit tests until localizationMixin issue is resolved