### PR TITLE
feat: dialog box when saving an existing learning path fails

### DIFF
--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -55,7 +55,7 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 			<d2l-backdrop id="save-backdrop" for-target="#save-buttons" no-animate-hide ?shown="${this._backdropOpen}"></d2l-backdrop>
 			<d2l-dialog id="save-failed-dialog" ?opened="${this._dialogOpen}" @d2l-dialog-close="${this._closeDialog}" title-text="${this.localize('text-dialogSaveTitle')}">
 				<div>${this.localize('text-dialogSaveContent')}</div>
-				<d2l-button slot="footer" primary data-dialog-action="okay">${this.localize('label.ok')}</d2l-button>
+				<d2l-button slot="footer" primary data-dialog-action="okay">${this.localize('label-ok')}</d2l-button>
 			</d2l-dialog>
 			`;
 	}
@@ -67,8 +67,8 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 
 	async _onSaveClick() {
 		this._backdropOpen = true;
-		await this.updateComplete;
 		try {
+			await this.updateComplete;
 			await this._state.push();
 		} catch (err) {
 			this._dialogOpen = true;

--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -1,6 +1,7 @@
+import '@brightspace-ui/core/components/alert/alert-toast.js';
 import '@brightspace-ui/core/components/backdrop/backdrop.js';
 import '@brightspace-ui/core/components/button/button.js';
-import '@brightspace-ui/core/components/alert/alert-toast.js';
+import '@brightspace-ui/core/components/dialog/dialog.js';
 import '../../common/d2l-activity-visibility.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
@@ -11,7 +12,10 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 
 	static get properties() {
 		return {
-			up: { type: Object, observable: observableTypes.link, rel: 'up'}
+			up: { type: Object, observable: observableTypes.link, rel: 'up'},
+			_backdropOpen: { type: Boolean },
+			_dialogOpen: { type: Boolean },
+			_toastOpen: { type: Boolean }
 		};
 	}
 
@@ -43,23 +47,37 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 				<d2l-hc-visibility-toggle  href="${this.href}" .token="${this.token}"></d2l-hc-visibility-toggle>
 			</div>
 			</div>
-			<d2l-alert-toast id="save-succeeded-toast" type="success" announce-text="${this.localize('text.saveComplete')}">
-				${this.localize('text.saveComplete')}
-			</d2l-alert-toast>
-			<div><slot name="save-status">${this.localize('text.saveStatus')}</slot></div>
-			<d2l-backdrop id="save-backdrop" for-target="#save-buttons" no-animate-hide></d2l-backdrop>
 
+			<d2l-alert-toast id="save-succeeded-toast" ?open="${this._toastOpen}" type="success"
+				announce-text="${this.localize('text.saveComplete')}">
+					${this.localize('text.saveComplete')}
+			</d2l-alert-toast>
+
+			<d2l-backdrop id="save-backdrop" for-target="#save-buttons" no-animate-hide ?shown="${this._backdropOpen}"></d2l-backdrop>
+			<d2l-dialog id="save-failed-dialog" ?opened="${this._dialogOpen}" @d2l-dialog-close="${this._closeDialog}" title-text="${this.localize('text.dialogSaveTitle')}">
+				<div>${this.localize('text.dialogSaveContent')}</div>
+				<d2l-button slot="footer" primary data-dialog-action="okay">${this.localize('label.ok')}</d2l-button>
+			</d2l-dialog>
 			`;
 	}
 
-	async _onSaveClick() {
-		const backdrop = this.shadowRoot.querySelector('#save-backdrop');
-		backdrop.shown = !backdrop.shown;
-		await this.updateComplete;
-		await this._state.push();
+	_closeDialog() {
+		this._dialogOpen = false;
+		this._backdropOpen = false;
+	}
 
-		this.shadowRoot.querySelector('#save-succeeded-toast').open = true;
-		backdrop.shown = !backdrop.shown;
+	async _onSaveClick() {
+		this._backdropOpen = true;
+		await this.updateComplete;
+		try {
+			await this._state.push();
+		} catch (err) {
+			this._dialogOpen = true;
+			return;
+		}
+
+		this._toastOpen = true;
+		this._backdropOpen = false;
 
 		this._pageRedirect();
 	}

--- a/components/activity/editor/lang/en.js
+++ b/components/activity/editor/lang/en.js
@@ -5,7 +5,10 @@ export default {
 	"action.cancel": "Cancel",
 	"action.saveClose": "Save and Close",
 	"label.instructions": "Instructions",
+	"label.ok": "OK",
 	"text.activities": "Activities",
+	"text.dialogSaveTitle": "Learning path changes could not be saved",
+	"text.dialogSaveContent": "Changes to this Learning Path could not be saved. You can try again after pressing OK.",
 	"text.saveComplete": "Save Complete",
-	"text.saveStatus": "Save status"
+	"text.saveStatus": "Save status",
 };


### PR DESCRIPTION
Context:
[US123433](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F466974478716)
When saving a learning path fails, we give the user a dialog box asking them to attempt to save again.

Quality:
Testing using polarisdev sitelord.
- tested by throwing explicitly from the try statement
- need to test push actually throwing