### PR TITLE
feat: dialog box for save failing on a new learning path

### DIFF
--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -8,6 +8,10 @@ import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundati
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { LocalizeFoundationEditor } from './lang/localization.js';
 
+const rels = Object.freeze({
+	specialization: 'https://api.brightspace.com/rels/specialization'
+});
+
 class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin(LitElement)) {
 
 	static get properties() {
@@ -15,7 +19,13 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 			up: { type: Object, observable: observableTypes.link, rel: 'up'},
 			_backdropOpen: { type: Boolean },
 			_dialogOpen: { type: Boolean },
-			_toastOpen: { type: Boolean }
+			_toastOpen: { type: Boolean },
+			_isNew: {
+				type: Boolean,
+				observable: observableTypes.classes,
+				method: classes => classes.includes('creating'),
+				route: [{observable: observableTypes.link, rel: rels.specialization}]
+			}
 		};
 	}
 
@@ -53,8 +63,8 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 			</d2l-alert-toast>
 
 			<d2l-backdrop id="save-backdrop" for-target="#save-buttons" no-animate-hide ?shown="${this._backdropOpen}"></d2l-backdrop>
-			<d2l-dialog id="save-failed-dialog" ?opened="${this._dialogOpen}" @d2l-dialog-close="${this._closeDialog}" title-text="${this.localize('text-dialogSaveTitle')}">
-				<div>${this.localize('text-dialogSaveContent')}</div>
+			<d2l-dialog id="save-failed-dialog" ?opened="${this._dialogOpen}" @d2l-dialog-close="${this._closeDialog}" title-text="${this._isNew ? this.localize('text-newDialogSaveTitle') : this.localize('text-editDialogSaveTitle')}">
+				<div>${this._isNew ? this.localize('text-newDialogSaveContent') : this.localize('text-editDialogSaveContent')}</div>
 				<d2l-button slot="footer" primary data-dialog-action="okay">${this.localize('label-ok')}</d2l-button>
 			</d2l-dialog>
 			`;

--- a/components/activity/editor/lang/en.js
+++ b/components/activity/editor/lang/en.js
@@ -1,14 +1,15 @@
 /* eslint quotes: 0 */
 
 export default {
-	"action-addActivity": "Add Activity",
-	"action-cancel": "Cancel",
-	"action-saveClose": "Save and Close",
-	"label-instructions": "Instructions",
-	"label-ok": "OK",
-	"text-activities": "Activities",
-	"text-dialogSaveTitle": "Learning path changes could not be saved",
-	"text-dialogSaveContent": "Changes to this Learning Path could not be saved. You can try again after pressing OK.",
-	"text-saveComplete": "Save Complete",
-	"text-saveStatus": "Save status",
+	"action-addActivity": "Add Activity", // Add a learning task to a list that are similar.
+	"action-cancel": "Cancel", // Undo all changes and return to the learning path admin page.
+	"action-saveClose": "Save and Close", // Save all changes and return to the learning path admin page.
+	"label-instructions": "Instructions", // Shows where the user should write instructions for an activity
+	"label-ok": "OK", // Confirm dialog box was read to return to editing learning path after save error
+	"text-activities": "Activities", // The following is a list of tasks to be completed to finish the learning path
+	"text-editDialogSaveTitle": "Learning Path changes not saved", // Error when the edits to the learning path could not be saved
+	"text-editDialogSaveContent": "Changes to this Learning Path could not be saved. You can try again after pressing OK.", // Message telling user changes could not be saved. Informs user they can try to save again after pressing ok to close dialog box
+	"text-newDialogSaveTitle": "Learning Path could not save", // Error when a new learning path could not be saved
+	"text-newDialogSaveContent": "This Learning Path could not be saved. You can try again after pressing OK.", // // Message telling user a new learning path could not be saved. Informs user they can try to save again after pressing ok to close dialog box
+	"text-saveComplete": "Save Complete" // Saving is complete and was successful
 };


### PR DESCRIPTION
Context:
[US123434](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F466974498476)
We want text that is different for saving failing on a new learning path.

Quality:
Tested on polarisdev2.
- new text shows up when learning path is new
- editing text shows up when learning path is old