### PR TITLE
feat: Dialog component for load failures

### DIFF
--- a/components/activity/dialog/README.md
+++ b/components/activity/dialog/README.md
@@ -1,0 +1,7 @@
+# d2l-activity-dialog
+
+Dialog components for activities.
+
+## d2l-activity-dialog-load-failed
+
+Displays a dialog when loading the hypermedia responses results in a non-200 response.

--- a/components/activity/dialog/d2l-activity-dialog-load-failed.js
+++ b/components/activity/dialog/d2l-activity-dialog-load-failed.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/dialog/dialog.js';
-import { css, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LitElement } from 'lit-element/lit-element.js';
 import { LocalizeDialog } from './lang/localize-dialog.js';
 
 const getType = (classes) => {

--- a/components/activity/dialog/d2l-activity-dialog-load-failed.js
+++ b/components/activity/dialog/d2l-activity-dialog-load-failed.js
@@ -13,7 +13,7 @@ class ActivityDialogLoadFailed extends HypermediaStateMixin(LocalizeDialog(LitEl
 
 	static get properties() {
 		return {
-			_type: { observable: observableTypes.classes, method: getType },
+			_type: { type: String, observable: observableTypes.classes, method: getType },
 			_loadFailureDialogOpen: { type: Boolean }
 		};
 	}

--- a/components/activity/dialog/d2l-activity-dialog-load-failed.js
+++ b/components/activity/dialog/d2l-activity-dialog-load-failed.js
@@ -1,0 +1,49 @@
+import '@brightspace-ui/core/components/dialog/dialog.js';
+import { css, LitElement } from 'lit-element/lit-element.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LocalizeDialog } from './lang/localize-dialog.js';
+
+const getType = (classes) => {
+	if (classes.includes('learning-path')) return 'learning-path';
+	return 'activity-usage';
+};
+
+class ActivityDialogLoadFailed extends HypermediaStateMixin(LocalizeDialog(LitElement)) {
+
+	static get properties() {
+		return {
+			_type: { observable: observableTypes.classes, method: getType },
+			_loadFailureDialogOpen: { type: Boolean }
+		};
+	}
+
+	render() {
+		if (!this._type) return null;
+
+		return html`
+		<d2l-dialog title-text="${this.localize(`${this._type}-text-title`)}" ?opened="${this._loadFailureDialogOpen}" @d2l-dialog-close="${this._onDialogClose}">
+			<div>${this.localize(`${this._type}-text-content`)}</div>
+			<d2l-button slot="footer" primary data-dialog-action="done" @click=${this._attemptLoad}>${this.localize('action-tryagain')}</d2l-button>
+			<d2l-button slot="footer" data-dialog-action>${this.localize('action-cancel')}</d2l-button>
+		</d2l-dialog>
+		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('_error') && this._error) {
+			this._loadFailureDialogOpen = true;
+		}
+	}
+
+	_attemptLoad() {
+		window.location.reload();
+	}
+
+	_onDialogClose() {
+		this._loadFailureDialogOpen = false;
+	}
+}
+
+customElements.define('d2l-activity-dialog-load-failed', ActivityDialogLoadFailed);

--- a/components/activity/dialog/lang/en.js
+++ b/components/activity/dialog/lang/en.js
@@ -1,0 +1,9 @@
+/* eslint quotes: 0 */
+export default  {
+	"learning-path-text-title": "Learning Path could not open", // title of the dialog that appears when a learning path doesn't load
+	"learning-path-text-content": "Whoops! Something went wrong and the Learning Path could not open. You can try again or cancel to go back.", // content of the dialog that appears when a learning path doesn't load
+	"activity-usage-text-title": "Activity could not open", // title of the dialog that appears when a generic activity doesn't load
+	"activity-usage-text-content": "Whoops! Something went wrong and the Activity could not open. You can try again or cancel to go back.", // content of the dialog that appears when a generic activity doesn't load
+	"action-tryagain": "Try Again", // button to attempt the same action again after a failure
+	"action-cancel": "Cancel", // button to go back after a failure
+};

--- a/components/activity/dialog/lang/localize-dialog.js
+++ b/components/activity/dialog/lang/localize-dialog.js
@@ -1,0 +1,9 @@
+import { getLocalizeResources } from '../../../../lang/localizeResources.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+export const LocalizeDialog = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, 'components/activity/dialog');
+	}
+};

--- a/components/activity/editor/d2l-hc-activity-editor.js
+++ b/components/activity/editor/d2l-hc-activity-editor.js
@@ -4,6 +4,7 @@ import './d2l-activity-editor-footer.js';
 import './d2l-activity-editor-header.js';
 import './d2l-activity-editor-sidebar.js';
 import './d2l-activity-editor-main.js';
+import '../dialog/d2l-activity-dialog-load-failed.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { nothing } from 'lit-html';
@@ -79,6 +80,13 @@ class ActivityEditor extends LitElement {
 					<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
 				</d2l-floating-buttons>
 			</div>
+			${this._renderLoadFailureDialog()}
+		`;
+	}
+
+	_renderLoadFailureDialog() {
+		return html`
+			<d2l-activity-dialog-load-failed href="${this.href}" .token="${this.token}"></d2l-activity-dialog-load-failed>
 		`;
 	}
 
@@ -95,6 +103,7 @@ class ActivityEditor extends LitElement {
 					<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
 				</div>
 			</d2l-template-primary-secondary>
+			${this._renderLoadFailureDialog()}
 		`;
 	}
 }


### PR DESCRIPTION
## Context
[US123433](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F466974478716&fdp=true&fdp=true&fdp=true?fdp=true)

First portion of story. 
- Creates a new component for displaying a dialog when an activity load fails.
- Added to the `d2l-hc-activity-editor`
- Component is generic and will intelligently display langs based on the classes
- Supports generic `activity-usage` and `learning-path`
- Cancel just closes the dialog currently - will add redirecting in a different PR

<img width="636" alt="Screen Shot 2021-01-14 at 1 28 37 PM" src="https://user-images.githubusercontent.com/2412740/104633041-97e8b880-566c-11eb-9fb1-08a760592984.png">

## Quality
- Manual testing by forcing the engine to throw an error
- There's a problem with the engine that's not catching errors correctly but is separate from this story