### PR TITLE
fix: do not reset on cancel

### DIFF
--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -108,7 +108,7 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 	}
 
 	_onCancelClick() {
-		this._state.reset();
+		//this._state.reset();
 		this._pageRedirect();
 	}
 


### PR DESCRIPTION
Context:
Reset is breaking. Specifically, the href is missing in the state. We don't really need to reset so we're not going to.