### PR TITLE
Feat: Description Auto grows to 5 lines.

### DIFF
--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -37,7 +37,7 @@ class ActivityDescriptionEditor extends LocalizeFoundationDescription(Hypermedia
 					position: absolute;
 					resize: none;
 					top: 0;
-					z-index:2;
+					z-index: 2;
 				}
 				.d2l-activity-description-editor {
 					min-height: 1rem;

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -25,29 +25,47 @@ class ActivityDescriptionEditor extends LocalizeFoundationDescription(Hypermedia
 	static get styles() {
 		return [ inputLabelStyles, inputStyles,
 			css`
-			@media (max-width: 615px) {
-				.d2l-activity-description-editor textarea {
-					height: 5rem;
+				@media (max-width: 615px) {
+					.d2l-activity-description-textfield {
+						height: 5rem;
+					}
 				}
-			}
 
-			.d2l-activity-description-editor textarea {
-				resize: none;
-			}
+				.d2l-activity-description-editor textarea {
+					height: 100%;
+					left: 0;
+					position: absolute;
+					resize: none;
+					top: 0;
+					z-index:2;
+				}
+				.d2l-activity-description-editor {
+					min-height: 1rem;
+					position: relative;
+				}
+				.d2l-activity-description-textfield {
+					line-height: normal;
+					max-height: 6rem;
+					visibility: hidden;
+				}
 			`
 		];
 	}
 
 	render() {
 		return this._loaded ? html`
-		<label class="d2l-activity-description-editor">
-			<span class="d2l-input-label">${this.localize('label-description')}</span>
+		<label class="d2l-input-label" for="textarea">
+			<span class="">${this.localize('label-description')}</span>
+		</label>
+		<div class="d2l-activity-description-editor">
+			<div class="d2l-activity-description-textfield d2l-input">${this.description}</div>
 			<textarea class="d2l-input"
 				@input="${this._onInputDescription}"
 				placeholder="${this.localize('input-description')}"
 				.value="${this.description}"
+				id="textarea"
 			>${this.description ? this.description : ''}</textarea>
-		</label>
+		</div>
 		` : html`<d2l-input-text label="${this.localize('label-description')}" skeleton></d2l-input-text>`;
 	}
 

--- a/components/activity/description/d2l-activity-description-editor.js
+++ b/components/activity/description/d2l-activity-description-editor.js
@@ -3,6 +3,7 @@ import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId.js';
 import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
 import { LocalizeFoundationDescription } from './lang/localization.js';
@@ -52,18 +53,23 @@ class ActivityDescriptionEditor extends LocalizeFoundationDescription(Hypermedia
 		];
 	}
 
+	constructor() {
+		super();
+		this._descriptionId = getUniqueId();
+	}
+
 	render() {
 		return this._loaded ? html`
-		<label class="d2l-input-label" for="textarea">
+		<label class="d2l-input-label" for="${this._descriptionId}">
 			<span class="">${this.localize('label-description')}</span>
 		</label>
 		<div class="d2l-activity-description-editor">
 			<div class="d2l-activity-description-textfield d2l-input">${this.description}</div>
 			<textarea class="d2l-input"
-				@input="${this._onInputDescription}"
-				placeholder="${this.localize('input-description')}"
 				.value="${this.description}"
-				id="textarea"
+				@input="${this._onInputDescription}"
+				id="${this._descriptionId}"
+				placeholder="${this.localize('input-description')}"
 			>${this.description ? this.description : ''}</textarea>
 		</div>
 		` : html`<d2l-input-text label="${this.localize('label-description')}" skeleton></d2l-input-text>`;


### PR DESCRIPTION
Basically, the description box now auto grows up to 5 lines big. The default size is now the same size as the input name box! Woot!