### PR TITLE
fix: Change the state when items are reordered

### DIFF
--- a/components/activity/editor/collection/d2l-activity-editor-main-collection.js
+++ b/components/activity/editor/collection/d2l-activity-editor-main-collection.js
@@ -170,7 +170,14 @@ class ActivityEditorMainCollection extends LocalizeFoundationEditor(SkeletonMixi
 
 	_moveItems(e) {
 		e.detail.reorder(this._items, { keyFn: (item) => item.properties.id || item.properties.actionState });
-		this.requestUpdate('_items', []);
+		this._state.updateProperties({
+			_items: {
+				observable: observableTypes.subEntities,
+				rel: rels.item,
+				value: this._items,
+				route: [{ observable: observableTypes.link, rel: rels.collection }]
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
## Context

**Before:** Open a learning path. Add more than one courses. Reorder courses. Add additional course(s).
Expected: courses that have been moved before second add to remain where they were in the list.
Actual: courses that have been moved are returned to the position they were added to.

**After:** State is updated when a user reorders items, so things maintain consistency.

## Quality
Tested with `polarisdev2` and local BSI