### PR TITLE
fix: shim appears when learning path is being saved

### DIFF
--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -68,7 +68,7 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 	render() {
 		return html`
 			<div class="d2l-activity-editor-save-buttons" id="${this.saveButtons}">
-				<d2l-button class="d2l-activity-editor-save-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-saveClose')}</d2l-button>
+				<div id="save-buttons"><d2l-button class="d2l-activity-editor-save-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-saveClose')}</d2l-button></div>
 				<d2l-button class="d2l-activity-editor-save-button" @click="${this._onCancelClick}" ?disabled="${!this._loaded}">${this.localize('action-cancel')}</d2l-button>
 				<d2l-hc-visibility-toggle class="d2l-activity-editor-save-buttons-visibility" href="${this.href}" .token="${this.token}" ?disabled="${!this._loaded}"></d2l-hc-visibility-toggle>
 			</div>
@@ -78,7 +78,7 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 					${this.localize('text-saveComplete')}
 			</d2l-alert-toast>
 
-			<d2l-backdrop id="save-backdrop" for-target="#save-buttons" no-animate-hide ?shown="${this._backdropOpen}"></d2l-backdrop>
+			<d2l-backdrop id="save-backdrop" for-target="save-buttons" ?shown="${this._backdropOpen}"></d2l-backdrop>
 			<d2l-dialog id="save-failed-dialog" ?opened="${this._dialogOpen}" @d2l-dialog-close="${this._closeDialog}" title-text="${this._isNew ? this.localize('text-newDialogSaveTitle') : this.localize('text-editDialogSaveTitle')}">
 				<div>${this._isNew ? this.localize('text-newDialogSaveContent') : this.localize('text-editDialogSaveContent')}</div>
 				<d2l-button slot="footer" primary data-dialog-action="okay">${this.localize('label-ok')}</d2l-button>
@@ -108,7 +108,6 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 	}
 
 	_onCancelClick() {
-		//this._state.reset();
 		this._pageRedirect();
 	}
 


### PR DESCRIPTION
Context:
[US42099](https://rally1.rallydev.com/#/357252966636ud/custom/367300408400?detail=%2Fdefect%2F485856032632)
The shim was not appearing while saving, only when an error dialog appeared.

Quality:
Tested on polarislocalbsi.


https://user-images.githubusercontent.com/69812595/104953433-66395f80-5994-11eb-9991-335ebfdfe806.mp4

