### PR TITLE
fix: footer correctly displayed in mobile mode

### DIFF
--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -51,10 +51,10 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 				display: flex;
 			}
 			@media only screen and (max-width: 615px) {
-				.d2l-desktop {
+				.d2l-desktop-button {
 					display: none;
 				}
-				.d2l-mobile {
+				.d2l-mobile-button {
 					display: inline-block;
 				}
 			}
@@ -62,10 +62,10 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 				.d2l-activity-editor-save-buttons-visibility {
 					width: 300px;
 				}
-				.d2l-desktop {
+				.d2l-desktop-button {
 					display: inline-block;
 				}
-				.d2l-mobile {
+				.d2l-mobile-button {
 					display: none;
 				}
 			}
@@ -82,8 +82,8 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 	render() {
 		return html`
 			<div class="d2l-activity-editor-save-buttons" id="${this.saveButtons}">
-				<div id="save-buttons" class="d2l-desktop"><d2l-button class="d2l-activity-editor-save-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-saveClose')}</d2l-button></div>
-				<div id="save-buttons" class="d2l-mobile"><d2l-button class="d2l-activity-editor-save-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">Save</d2l-button></div>
+				<d2l-button class="d2l-activity-editor-save-button d2l-desktop-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-saveClose')}</d2l-button>
+				<d2l-button class="d2l-activity-editor-save-button d2l-mobile-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">Save</d2l-button>
 				<d2l-button class="d2l-activity-editor-save-button" @click="${this._onCancelClick}" ?disabled="${!this._loaded}">${this.localize('action-cancel')}</d2l-button>
 				<d2l-hc-visibility-toggle class="d2l-activity-editor-save-buttons-visibility" href="${this.href}" .token="${this.token}" ?disabled="${!this._loaded}"></d2l-hc-visibility-toggle>
 			</div>
@@ -93,7 +93,7 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 					${this.localize('text-saveComplete')}
 			</d2l-alert-toast>
 
-			<d2l-backdrop id="save-backdrop" for-target="save-buttons" ?shown="${this._backdropOpen}"></d2l-backdrop>
+			<d2l-backdrop id="save-backdrop" for-target="${this.saveButtons}" ?shown="${this._backdropOpen}"></d2l-backdrop>
 			<d2l-dialog id="save-failed-dialog" ?opened="${this._dialogOpen}" @d2l-dialog-close="${this._closeDialog}" title-text="${this._isNew ? this.localize('text-newDialogSaveTitle') : this.localize('text-editDialogSaveTitle')}">
 				<div>${this._isNew ? this.localize('text-newDialogSaveContent') : this.localize('text-editDialogSaveContent')}</div>
 				<d2l-button slot="footer" primary data-dialog-action="okay">${this.localize('label-ok')}</d2l-button>

--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -50,9 +50,23 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 			.d2l-activity-editor-save-buttons {
 				display: flex;
 			}
-			@media only screen and (min-width: 650px) {
+			@media only screen and (max-width: 615px) {
+				.d2l-desktop {
+					display: none;
+				}
+				.d2l-mobile {
+					display: inline-block;
+				}
+			}
+			@media only screen and (min-width: 615px) {
 				.d2l-activity-editor-save-buttons-visibility {
 					width: 300px;
+				}
+				.d2l-desktop {
+					display: inline-block;
+				}
+				.d2l-mobile {
+					display: none;
 				}
 			}
 		`];
@@ -68,7 +82,8 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 	render() {
 		return html`
 			<div class="d2l-activity-editor-save-buttons" id="${this.saveButtons}">
-				<div id="save-buttons"><d2l-button class="d2l-activity-editor-save-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-saveClose')}</d2l-button></div>
+				<div id="save-buttons" class="d2l-desktop"><d2l-button class="d2l-activity-editor-save-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-saveClose')}</d2l-button></div>
+				<div id="save-buttons" class="d2l-mobile"><d2l-button class="d2l-activity-editor-save-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">Save</d2l-button></div>
 				<d2l-button class="d2l-activity-editor-save-button" @click="${this._onCancelClick}" ?disabled="${!this._loaded}">${this.localize('action-cancel')}</d2l-button>
 				<d2l-hc-visibility-toggle class="d2l-activity-editor-save-buttons-visibility" href="${this.href}" .token="${this.token}" ?disabled="${!this._loaded}"></d2l-hc-visibility-toggle>
 			</div>

--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -50,13 +50,11 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 			.d2l-activity-editor-save-buttons {
 				display: flex;
 			}
-			@media only screen and (max-width: 615px) {
-				.d2l-desktop-button {
-					display: none;
-				}
-				.d2l-mobile-button {
-					display: inline-block;
-				}
+			.d2l-desktop-button {
+				display: none;
+			}
+			.d2l-mobile-button {
+				display: inline-block;
 			}
 			@media only screen and (min-width: 615px) {
 				.d2l-activity-editor-save-buttons-visibility {
@@ -83,7 +81,7 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 		return html`
 			<div class="d2l-activity-editor-save-buttons" id="${this.saveButtons}">
 				<d2l-button class="d2l-activity-editor-save-button d2l-desktop-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-saveClose')}</d2l-button>
-				<d2l-button class="d2l-activity-editor-save-button d2l-mobile-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">Save</d2l-button>
+				<d2l-button class="d2l-activity-editor-save-button d2l-mobile-button" primary @click="${this._onSaveClick}" ?disabled="${!this._loaded}">${this.localize('action-save')}</d2l-button>
 				<d2l-button class="d2l-activity-editor-save-button" @click="${this._onCancelClick}" ?disabled="${!this._loaded}">${this.localize('action-cancel')}</d2l-button>
 				<d2l-hc-visibility-toggle class="d2l-activity-editor-save-buttons-visibility" href="${this.href}" .token="${this.token}" ?disabled="${!this._loaded}"></d2l-hc-visibility-toggle>
 			</div>

--- a/components/activity/editor/lang/en.js
+++ b/components/activity/editor/lang/en.js
@@ -3,6 +3,7 @@
 export default {
 	"action-addActivity": "Add Activity", // Add a learning task to a list that are similar.
 	"action-cancel": "Cancel", // Undo all changes and return to the learning path admin page.
+	"action-save": "Save", // Save all changes and return to the learning path admin page -- visible when screen is small
 	"action-saveClose": "Save and Close", // Save all changes and return to the learning path admin page.
 	"label-instructions": "Instructions", // Shows where the user should write instructions for an activity
 	"label-ok": "OK", // Confirm dialog box was read to return to editing learning path after save error


### PR DESCRIPTION
### Context
[DE42111](https://rally1.rallydev.com/#/357252966636ud/custom/367300408400?detail=%2Fdefect%2F485887163996)
The footer was not being resized to fit a mobile display.

### Quality:
Discussed how to address with Abbie. Decided we would reduce "Save and close" to "Save" on mobile displays like assignments does.
Tested on polarislocalbsi

https://user-images.githubusercontent.com/69812595/104960150-ace18680-59a1-11eb-8f77-757ccb4b9d79.mp4

