### PR TITLE
fix: prevents saving empty name

### DIFF
--- a/components/activity/name/d2l-activity-name-editor.js
+++ b/components/activity/name/d2l-activity-name-editor.js
@@ -34,7 +34,11 @@ class ActivityNameEditor extends LocalizeActivityName(HypermediaStateMixin(LitEl
 
 	_onInputName(e) {
 		if (this.updateName.has) {
-			this.updateName.commit({name: { observable: observableTypes.property, value: e.target.value} });
+			const name = e.target.value.trim();
+			if (name.length === 0) {
+				return;
+			}
+			this.updateName.commit({name: { observable: observableTypes.property, value: name} });
 		}
 	}
 

--- a/components/activity/name/d2l-activity-name-editor.js
+++ b/components/activity/name/d2l-activity-name-editor.js
@@ -28,6 +28,7 @@ class ActivityNameEditor extends LocalizeActivityName(HypermediaStateMixin(LitEl
 				placeholder="${this.localize('action-name')}"
 				value="${this.name}"
 				?skeleton="${!this._loaded}"
+				required
 			></d2l-input-text>
 		`;
 	}


### PR DESCRIPTION
### Context:
[DE42104](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F485864994084l)
[DE42101](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F485859664416)

When saving, leading and trailing whitespace are currently both saved. Also, a learning path with an empty name can be saved.

This solution trims the whitespace while text is being entered.
For saving with an empty name, if the name is deleted, the learning path will save with the non-empty name it had. If the entire name was selected and deleted at once, the name is unchanged. If the name was deleted one character at a time, the last character deleted is saved as the name.

### Quality:
Tested on polarislocalbsi.
