### PR TITLE
fix: remove during keyboard mode removes course

### DIFF
--- a/components/activity/list/d2l-activity-list-item-accumulator.js
+++ b/components/activity/list/d2l-activity-list-item-accumulator.js
@@ -10,6 +10,10 @@ import { LitElement } from 'lit-element/lit-element.js';
 const rels = Object.freeze({
 	activityUsage: 'https://activities.api.brightspace.com/rels/activity-usage'
 });
+const keyCodes = Object.freeze({
+	ENTER: 13,
+	SPACE: 32
+});
 
 class ActivityListItemAccumulator extends HypermediaStateMixin(ListItemAccumulatorMixin(LitElement)) {
 	static get properties() {
@@ -23,7 +27,7 @@ class ActivityListItemAccumulator extends HypermediaStateMixin(ListItemAccumulat
 			illustration: html`${guard([this._activityHref, this.token], () => html`<d2l-activity-image href="${this._activityHref}" .token="${this.token}"></d2l-activity-image>`)}`,
 			title: html`${guard([this._activityHref, this.token], () => html`<d2l-activity-name href="${this._activityHref}" .token="${this.token}"></d2l-activity-name>`)}`,
 			secondary: html`${guard([this._activityHref, this.token], () => html`<d2l-activity-type href="${this._activityHref}" .token="${this.token}" slot="supporting-info"></d2l-activity-type>`)}`,
-			secondaryAction: html`${guard([this._activityHref, this.token], () => html`<d2l-menu-item text="Remove" @click="${this._onRemoveClick}"></d2l-menu-item>`)}`
+			secondaryAction: html`${guard([this._activityHref, this.token], () => html`<d2l-menu-item text="Remove" @click="${this._onRemoveClick}" @keydown="${this._onRemoveKeydown}"></d2l-menu-item>`)}`
 		});
 	}
 
@@ -33,6 +37,16 @@ class ActivityListItemAccumulator extends HypermediaStateMixin(ListItemAccumulat
 			bubbles: true
 		});
 		this.dispatchEvent(event);
+	}
+
+	_onRemoveKeydown(e) {
+		if (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) {
+			const event = new CustomEvent('d2l-remove-collection-activity-item', {
+				detail: { key: this.key },
+				bubbles: true
+			});
+			this.dispatchEvent(event);
+		}
 	}
 }
 customElements.define('d2l-activity-list-item-accumulator', ActivityListItemAccumulator);

--- a/components/activity/list/d2l-activity-list-item-accumulator.js
+++ b/components/activity/list/d2l-activity-list-item-accumulator.js
@@ -41,11 +41,7 @@ class ActivityListItemAccumulator extends HypermediaStateMixin(ListItemAccumulat
 
 	_onRemoveKeydown(e) {
 		if (e.keyCode === keyCodes.ENTER || e.keyCode === keyCodes.SPACE) {
-			const event = new CustomEvent('d2l-remove-collection-activity-item', {
-				detail: { key: this.key },
-				bubbles: true
-			});
-			this.dispatchEvent(event);
+			this._onRemoveClick();
 		}
 	}
 }


### PR DESCRIPTION
###Context:
[DE42122](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F485896470472)

Currently, using remove during keyboard mode does not remove the item from the list.
The solution here adds an action for keydown on the item. This is kind of clunky and ideally the list-item-accummulator-mixin would handle this in the future.

### Quality:
Tested on polarislocalbsi.


https://user-images.githubusercontent.com/69812595/105064561-f043ff80-5a4a-11eb-9062-fb26119c7853.mp4

