### PR TITLE
fix: show load more error under button

### DIFF
--- a/components/activity/editor/collection/d2l-activity-editor-collection-add.js
+++ b/components/activity/editor/collection/d2l-activity-editor-collection-add.js
@@ -11,7 +11,6 @@ import '../../image/d2l-activity-image.js';
 import '../../name/d2l-activity-name.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
-//import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { guard } from 'lit-html/directives/guard';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
@@ -84,6 +83,10 @@ class ActivityEditorCollectionAdd extends HypermediaStateMixin(LocalizeCollectio
 			.d2l-add-activity-dialog-load-more {
 				margin: 0.5rem 0;
 			}
+			.d2l-add-activity-dialog-load-more-error{
+				min-height: 1rem;
+			}
+
 			.d2l-add-activity-dialog-selection-count {
 				align-self: center;
 				color: var(--d2l-color-ferrite);
@@ -160,7 +163,7 @@ class ActivityEditorCollectionAdd extends HypermediaStateMixin(LocalizeCollectio
 			if (this._hasAction('_startAddExistingNext') && !this._isLoadingMore) {
 				return html`
 					<d2l-button @click="${this._onLoadMoreClick}">${this.localize('button-loadMore')}</d2l-button>
-					<div class="d2l-compact-body" aria-live="assertive">
+					<div class="d2l-compact-body d2l-add-activity-dialog-load-more-error" aria-live="assertive">
 						${this._loadMoreFailed ? this.localize('text-loadMoreError') : null }
 					</div>
 				`;
@@ -270,7 +273,6 @@ class ActivityEditorCollectionAdd extends HypermediaStateMixin(LocalizeCollectio
 			this._candidates.push(...newCandidates);
 			this._loadMoreFailed = false;
 		} catch (e) {
-			console.log(e);
 			this._loadMoreFailed = true;
 		}
 

--- a/components/activity/editor/collection/d2l-activity-editor-collection-add.js
+++ b/components/activity/editor/collection/d2l-activity-editor-collection-add.js
@@ -261,6 +261,8 @@ class ActivityEditorCollectionAdd extends HypermediaStateMixin(LocalizeCollectio
 	}
 
 	_onCloseDialog() {
+		// reset errror state
+		this._loadMoreFailed = false;
 		this._dialogOpened = false;
 		this.clearSelected();
 	}

--- a/components/activity/editor/collection/lang/en.js
+++ b/components/activity/editor/collection/lang/en.js
@@ -11,4 +11,5 @@ export default  {
 	"label-search": "Search", // When adding activities to the learning path, this is where you can search for potential activities to add.
 	"list-noActivitiesFound": "There were no activities found using your search term.", // Displayed when the learning path has no activities while in the screen that allows you to add them.
 	"listitem-alreadyAdded": "Already added", // When seeing a list of activities that can be added to the learning path, these activities have already in the list.
+	"text-loadMoreError": "Failed to load activities", // When adding activities to the learning path, this is text will appear when the load more button results in an error.
 };


### PR DESCRIPTION
[DE42126](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F485904871028)

```Context```
The load more button would get stuck as a spinner when a network failure occurred. I've added a try/catch around the call to display an error message when this happens and release the isLoadingMore flag. 

```Quality```
Manual testing using polarisLocalBSI
1) load the page
2) in dev tools, set network connection to offline
3) clicking load more will cause the button to revert back to a button and error message is shown
4) in dev tools, set network connection to online
5) click load more, new activities are loaded and error is removed
