### PR TITLE
fix: footer appears behind browse library dialog

### DIFF
--- a/components/activity/editor/d2l-activity-editor-footer.js
+++ b/components/activity/editor/d2l-activity-editor-footer.js
@@ -49,7 +49,6 @@ class ActivityEditorFooter extends LocalizeFoundationEditor(HypermediaStateMixin
 			}
 			.d2l-activity-editor-save-buttons {
 				display: flex;
-				z-index: 999;
 			}
 			.d2l-desktop-button {
 				display: none;

--- a/components/activity/editor/d2l-hc-activity-editor.js
+++ b/components/activity/editor/d2l-hc-activity-editor.js
@@ -60,7 +60,6 @@ class ActivityEditor extends LitElement {
 				left: 0;
 				position: fixed;
 				right: 0;
-				z-index: 999;
 			}
 			.d2l-activity-editor-template-default-footer * {
 				margin: auto;


### PR DESCRIPTION
### Context:
[DE42228](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F486927762512)
In firefox, the save and close, cancel, and visibility are appearing in front of the shim from the collection dialog.


### Quality:
Tested on polarislocalbsi in chrome and firefox.