### PR TITLE
fix: Removed aria-live to prevent SR reading changes

### DIFF
--- a/components/activity/editor/collection/d2l-activity-editor-collection-add.js
+++ b/components/activity/editor/collection/d2l-activity-editor-collection-add.js
@@ -167,7 +167,7 @@ class ActivityEditorCollectionAdd extends HypermediaStateMixin(LocalizeCollectio
 
 			<div class="dialog-div">
 				<d2l-dialog id="dialog" ?opened="${this._dialogOpened}" title-text="${this.localize('dialog-browseActivityLibrary')}" @d2l-dialog-close="${this._onCloseDialog}">
-					<div class="d2l-add-activity-dialog" aria-live="polite" aria-busy="${!this._candidates}">
+					<div class="d2l-add-activity-dialog" aria-busy="${!this._candidates}">
 						<div class="d2l-add-activity-dialog-header">
 							<div>${this._hasAction('_startAddExistingSearch') ? html`
 								<d2l-input-search label="${this.localize('label-search')}" placeholder="${this.localize('input-searchPlaceholder')}" @d2l-input-search-searched="${this._onSearch}"></d2l-input-search>

--- a/components/common/lang/en.js
+++ b/components/common/lang/en.js
@@ -1,5 +1,5 @@
 /* eslint quotes: 0 */
 
 export default {
-	name: "Name" // Name of a course, a user or anything type of name/title of something.
+	name: "Item is loading" // Name of a course, a user or anything type of name/title of something.
 };


### PR DESCRIPTION
[DE42282](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F489328036512)

```Context```
Clicking the load more button would trigger the screen reader to read each new activity name as they were loaded. Skeleton items were also being read as "name". This caused some spam.

The dialog was created as an aria-live region that will announce changes, so I've removed the attribute. 

```Quality```
Tested using NVDA screen reader
1) Clicking load more no longer causes activities to be announced
2) Tabbing through the new activities will continue to announce the name as they receive focus