### PR TITLE
fix: Ten/localize list remove

### DIFF
--- a/components/activity/list/d2l-activity-list-item-accumulator.js
+++ b/components/activity/list/d2l-activity-list-item-accumulator.js
@@ -6,6 +6,7 @@ import { guard } from 'lit-html/directives/guard';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { ListItemAccumulatorMixin } from '@brightspace-ui-labs/list-item-accumulator/list-item-accumulator-mixin.js';
 import { LitElement } from 'lit-element/lit-element.js';
+import { LocalizeActivityList } from './lang/localization.js';
 
 const rels = Object.freeze({
 	activityUsage: 'https://activities.api.brightspace.com/rels/activity-usage'
@@ -15,7 +16,7 @@ const keyCodes = Object.freeze({
 	SPACE: 32
 });
 
-class ActivityListItemAccumulator extends HypermediaStateMixin(ListItemAccumulatorMixin(LitElement)) {
+class ActivityListItemAccumulator extends LocalizeActivityList(HypermediaStateMixin(ListItemAccumulatorMixin(LitElement))) {
 	static get properties() {
 		return {
 			_activityHref: { observable: observableTypes.link, rel: rels.activityUsage }
@@ -27,7 +28,7 @@ class ActivityListItemAccumulator extends HypermediaStateMixin(ListItemAccumulat
 			illustration: html`${guard([this._activityHref, this.token], () => html`<d2l-activity-image href="${this._activityHref}" .token="${this.token}"></d2l-activity-image>`)}`,
 			title: html`${guard([this._activityHref, this.token], () => html`<d2l-activity-name href="${this._activityHref}" .token="${this.token}"></d2l-activity-name>`)}`,
 			secondary: html`${guard([this._activityHref, this.token], () => html`<d2l-activity-type href="${this._activityHref}" .token="${this.token}" slot="supporting-info"></d2l-activity-type>`)}`,
-			secondaryAction: html`${guard([this._activityHref, this.token], () => html`<d2l-menu-item text="Remove" @click="${this._onRemoveClick}" @keydown="${this._onRemoveKeydown}"></d2l-menu-item>`)}`
+			secondaryAction: html`${guard([this._activityHref, this.token], () => html`<d2l-menu-item text="${this.localize('action-remove')}" @click="${this._onRemoveClick}" @keydown="${this._onRemoveKeydown}"></d2l-menu-item>`)}`
 		});
 	}
 

--- a/components/activity/list/lang/ar.js
+++ b/components/activity/list/lang/ar.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "إزالة", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/de.js
+++ b/components/activity/list/lang/de.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "entfernen", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/de.js
+++ b/components/activity/list/lang/de.js
@@ -1,5 +1,5 @@
 /* eslint quotes: 0 */
 
 export default {
-	"action-remove": "entfernen", // An action to remove a learning task from a list of tasks that are related
+	"action-remove": "Entfernen", // An action to remove a learning task from a list of tasks that are related
 };

--- a/components/activity/list/lang/en.js
+++ b/components/activity/list/lang/en.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "Remove" // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/es.js
+++ b/components/activity/list/lang/es.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "Eliminar", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/fr.js
+++ b/components/activity/list/lang/fr.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "Supprimer", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/ja.js
+++ b/components/activity/list/lang/ja.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "の削除", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/ko.js
+++ b/components/activity/list/lang/ko.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "제거", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/localization.js
+++ b/components/activity/list/lang/localization.js
@@ -1,0 +1,62 @@
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+export const LocalizeActivityList = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+		let translations;
+		for await (const lang of langs) {
+			switch (lang) {
+				case 'ar':
+					translations = await import('./ar.js');
+					break;
+				case 'de':
+					translations = await import('./de.js');
+					break;
+				case 'en':
+					translations = await import('./en.js');
+					break;
+				case 'es':
+					translations = await import('./es.js');
+					break;
+				case 'fr':
+					translations = await import('./fr.js');
+					break;
+				case 'ja':
+					translations = await import('./ja.js');
+					break;
+				case 'ko':
+					translations = await import('./ko.js');
+					break;
+				case 'nl':
+					translations = await import('./nl.js');
+					break;
+				case 'pt':
+					translations = await import('./pt.js');
+					break;
+				case 'sv':
+					translations = await import('./sv.js');
+					break;
+				case 'tr':
+					translations = await import('./tr.js');
+					break;
+				case 'zh-tw':
+					translations = await import('./zh-tw.js');
+					break;
+				case 'zh':
+					translations = await import('./zh.js');
+					break;
+			}
+			if (translations && translations.default) {
+				return {
+					language: lang,
+					resources: translations.default
+				};
+			}
+		}
+		translations = await import('./en.js');
+		return {
+			language: 'en',
+			resources: translations.default
+		};
+	}
+};

--- a/components/activity/list/lang/nl.js
+++ b/components/activity/list/lang/nl.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "verwijderen", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/nl.js
+++ b/components/activity/list/lang/nl.js
@@ -1,5 +1,5 @@
 /* eslint quotes: 0 */
 
 export default {
-	"action-remove": "verwijderen", // An action to remove a learning task from a list of tasks that are related
+	"action-remove": "Verwijderen", // An action to remove a learning task from a list of tasks that are related
 };

--- a/components/activity/list/lang/pt.js
+++ b/components/activity/list/lang/pt.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "Remover", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/sv.js
+++ b/components/activity/list/lang/sv.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "Ta bort", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/tr.js
+++ b/components/activity/list/lang/tr.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "soru başlığını kaldır", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/tr.js
+++ b/components/activity/list/lang/tr.js
@@ -1,5 +1,5 @@
 /* eslint quotes: 0 */
 
 export default {
-	"action-remove": "soru başlığını kaldır", // An action to remove a learning task from a list of tasks that are related
+	"action-remove": "Soru başlığını kaldır", // An action to remove a learning task from a list of tasks that are related
 };

--- a/components/activity/list/lang/zh-tw.js
+++ b/components/activity/list/lang/zh-tw.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "移除", // An action to remove a learning task from a list of tasks that are related
+};

--- a/components/activity/list/lang/zh.js
+++ b/components/activity/list/lang/zh.js
@@ -1,0 +1,5 @@
+/* eslint quotes: 0 */
+
+export default {
+	"action-remove": "删除", // An action to remove a learning task from a list of tasks that are related
+};

--- a/foundation-components.serge.json
+++ b/foundation-components.serge.json
@@ -98,7 +98,7 @@
     "name": "Common",
     "source_dir": "components/common/lang",
     "source_match": "en\\.js$",
-    "output_file_path": "FileLocation/%LANG%.json",
+    "output_file_path": "components/common/lang/%LANG%.json",
     "parser_plugin": {
       "plugin": "parse_js"
     },
@@ -122,7 +122,7 @@
     "name": "ActivityList",
     "source_dir": "components/activity/list/lang",
     "source_match": "en\\.js$",
-    "output_file_path": "FileLocation/%LANG%.json",
+    "output_file_path": "components/activity/list/lang/%LANG%.json",
     "parser_plugin": {
       "plugin": "parse_js"
     },

--- a/foundation-components.serge.json
+++ b/foundation-components.serge.json
@@ -117,5 +117,29 @@
       "zh-cn zh",
       "zh-tw zh-tw"
     ]
+  },
+  {
+    "name": "ActivityList",
+    "source_dir": "components/activity/list/lang",
+    "source_match": "en\\.js$",
+    "output_file_path": "FileLocation/%LANG%.json",
+    "parser_plugin": {
+      "plugin": "parse_js"
+    },
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ]
   }
 ]


### PR DESCRIPTION
### Context:
[DE42167](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F486263074800)
The remove word is not localized in the context menu for list items.

### Quality:
Tested in polarislocalbsi.
- tested English: 'Remove' was shown
- tested French: 'Supprimer' was shown