### PR TITLE
feat: activity editor defaults to primary-secondary template

### DIFF
--- a/components/activity/editor/d2l-hc-activity-editor.js
+++ b/components/activity/editor/d2l-hc-activity-editor.js
@@ -24,23 +24,10 @@ class ActivityEditor extends LitElement {
 			:host {
 				display: block;
 			}
-			.d2l-activity-editor-template-primary-secondary {
-				display: grid;
-				grid-template-areas:
-					"header"
-					"content"
-					"footer";
-				grid-template-columns: auto;
-				grid-template-rows: auto 1fr auto;
-				height: calc(100vh - 106px);
-				margin: auto;
-				max-width: 1230px;
-				overflow-y: scroll;
+			.d2l-primary-secondary {
 				position: relative;
-				border: none;
 			}
-
-			.d2l-activity-editor-template-default {
+			.d2l-activity-editor-template {
 				display: grid;
 				grid-template-areas:
 					"header"
@@ -112,7 +99,7 @@ class ActivityEditor extends LitElement {
 
 	render() {
 		const templates = {
-			'default': () => this._renderDefault(),
+			'single-pane': () => this._renderSinglePane(),
 			'primary-secondary': () => this._renderPrimarySecondary()
 		};
 
@@ -124,9 +111,9 @@ class ActivityEditor extends LitElement {
 		return templates[this.template]();
 	}
 
-	_renderDefault() {
+	_renderSinglePane() {
 		return html`
-			<div class="d2l-template-scroll d2l-activity-editor-template-default">
+			<div class="d2l-template-scroll d2l-activity-editor-template">
 				${this.noHeader ? nothing : html`
 					<d2l-activity-editor-header href="${this.href}" .token="${this.token}"></d2l-activity-editor-header>
 				`}
@@ -148,7 +135,7 @@ class ActivityEditor extends LitElement {
 
 	_renderPrimarySecondary() {
 		return html`
-			<div class="d2l-template-scroll d2l-activity-editor-template-primary-secondary">
+			<div class="d2l-template-scroll d2l-activity-editor-template d2l-primary-secondary">
 				<d2l-template-primary-secondary background-shading="secondary">
 					<slot name="editor-nav" slot="header"></slot>
 					${this.noHeader ? nothing : html`

--- a/components/activity/editor/d2l-hc-activity-editor.js
+++ b/components/activity/editor/d2l-hc-activity-editor.js
@@ -32,11 +32,12 @@ class ActivityEditor extends LitElement {
 					"footer";
 				grid-template-columns: auto;
 				grid-template-rows: auto 1fr auto;
-				height: calc(100vh - 134px);
+				height: calc(100vh - 106px);
 				margin: auto;
 				max-width: 1230px;
 				overflow-y: scroll;
 				position: relative;
+				border: none;
 			}
 
 			.d2l-activity-editor-template-default {
@@ -62,7 +63,7 @@ class ActivityEditor extends LitElement {
 			iron-overlay-backdrop {
 				--iron-overlay-backdrop-opacity: 0.0;
 			}
-			.d2l-activity-editor-template-default-footer {
+			.d2l-activity-editor-template-footer {
 				background-color: #ffffff;
 				background-color: rgba(255, 255, 255, 0.88);
 				border-top-color: var(--d2l-color-mica);
@@ -74,7 +75,7 @@ class ActivityEditor extends LitElement {
 				position: fixed;
 				right: 0;
 			}
-			.d2l-activity-editor-template-default-footer * {
+			.d2l-activity-editor-template-footer * {
 				margin: auto;
 				max-width: 1230px;
 				padding: 0.55rem 1.7rem 0.6rem 1.7rem;
@@ -125,13 +126,13 @@ class ActivityEditor extends LitElement {
 
 	_renderDefault() {
 		return html`
-			<div class="d2l-activity-editor-template-default d2l-template-scroll">
+			<div class="d2l-template-scroll d2l-activity-editor-template-default">
 				${this.noHeader ? nothing : html`
 					<d2l-activity-editor-header href="${this.href}" .token="${this.token}"></d2l-activity-editor-header>
 				`}
 				<d2l-activity-editor-main href="${this.href}" .token="${this.token}"></d2l-activity-editor-main>
 				<div class="d2l-actiity-editor-template-footer-space"></div>
-				<div class="d2l-activity-editor-template-default-footer">
+				<div class="d2l-activity-editor-template-footer">
 					<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
 				</div>
 			</div>
@@ -156,7 +157,9 @@ class ActivityEditor extends LitElement {
 					<d2l-activity-editor-main slot="primary" href="${this.href}" .token="${this.token}" class="d2l-activity-editor-main"></d2l-activity-editor-main>
 					<d2l-activity-editor-sidebar slot="secondary" href="${this.href}" .token="${this.token}" class="d2l-activity-editor-sidebar"></d2l-activity-editor-sidebar>
 					<div slot="footer">
-						<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
+					<div class="d2l-activity-editor-template-footer">
+						<d2l-activity-editor-footer slot="primary" href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
+					</div>
 					</div>
 				</d2l-template-primary-secondary>
 			</div>

--- a/components/activity/editor/d2l-hc-activity-editor.js
+++ b/components/activity/editor/d2l-hc-activity-editor.js
@@ -24,6 +24,20 @@ class ActivityEditor extends LitElement {
 			:host {
 				display: block;
 			}
+			.d2l-activity-editor-template-primary-secondary {
+				display: grid;
+				grid-template-areas:
+					"header"
+					"content"
+					"footer";
+				grid-template-columns: auto;
+				grid-template-rows: auto 1fr auto;
+				height: calc(100vh - 134px);
+				margin: auto;
+				max-width: 1230px;
+				overflow-y: scroll;
+				position: relative;
+			}
 
 			.d2l-activity-editor-template-default {
 				display: grid;
@@ -38,7 +52,6 @@ class ActivityEditor extends LitElement {
 				max-width: 1230px;
 				overflow-y: scroll;
 			}
-
 			[class^="d2l-activity-editor-main"] {
 				display: block;
 			}
@@ -66,7 +79,7 @@ class ActivityEditor extends LitElement {
 				max-width: 1230px;
 				padding: 0.55rem 1.7rem 0.6rem 1.7rem;
 			}
-			.d2l-actiity-editor-template-footer-space {
+			.d2l-activity-editor-template-footer-space {
 				height: 0px;
 			}
 
@@ -93,7 +106,7 @@ class ActivityEditor extends LitElement {
 
 	constructor() {
 		super();
-		this.template = 'default';
+		this.template = 'primary-secondary';
 	}
 
 	render() {
@@ -134,17 +147,19 @@ class ActivityEditor extends LitElement {
 
 	_renderPrimarySecondary() {
 		return html`
-			<d2l-template-primary-secondary background-shading="secondary">
-				<slot name="editor-nav" slot="header"></slot>
-				${this.noHeader ? nothing : html`
-					<d2l-activity-editor-header slot="primary" href="${this.href}" .token="${this.token}"></d2l-activity-editor-header>
-				`}
-				<d2l-activity-editor-main slot="primary" href="${this.href}" .token="${this.token}" class="d2l-activity-editor-main"></d2l-activity-editor-main>
-				<d2l-activity-editor-sidebar slot="secondary" href="${this.href}" .token="${this.token}" class="d2l-activity-editor-sidebar"></d2l-activity-editor-sidebar>
-				<div slot="footer">
-					<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
-				</div>
-			</d2l-template-primary-secondary>
+			<div class="d2l-template-scroll d2l-activity-editor-template-primary-secondary">
+				<d2l-template-primary-secondary background-shading="secondary">
+					<slot name="editor-nav" slot="header"></slot>
+					${this.noHeader ? nothing : html`
+						<d2l-activity-editor-header slot="primary" href="${this.href}" .token="${this.token}"></d2l-activity-editor-header>
+					`}
+					<d2l-activity-editor-main slot="primary" href="${this.href}" .token="${this.token}" class="d2l-activity-editor-main"></d2l-activity-editor-main>
+					<d2l-activity-editor-sidebar slot="secondary" href="${this.href}" .token="${this.token}" class="d2l-activity-editor-sidebar"></d2l-activity-editor-sidebar>
+					<div slot="footer">
+						<d2l-activity-editor-footer href="${this.href}" .token="${this.token}"></d2l-activity-editor-footer>
+					</div>
+				</d2l-template-primary-secondary>
+			</div>
 			${this._renderLoadFailureDialog()}
 		`;
 	}

--- a/features/assignments/d2l-activity-editor-submission.js
+++ b/features/assignments/d2l-activity-editor-submission.js
@@ -1,4 +1,4 @@
-import '../../components/activity/type/d2l-activity-type-editor.js';
+import '../../components/activity/type/d2l-activity-type.js';
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import { bodyCompactStyles, bodySmallStyles, heading3Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';


### PR DESCRIPTION
### Context: 
[US122674](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F458814721568)
The learning path editor needs to be switched to use primary-secondary to accommodate additional information. This pr is updating the editor to use the template but does not use the secondary area yet.
Some CSS formatting still needs to be done.

![primary-secondary](https://user-images.githubusercontent.com/69812595/108415150-236ce080-71fb-11eb-9ac0-d97fda1ba5e6.png)


### Quality:
- tested locally in sitelord with local bsi