### PR TITLE
feat: Added the discover component and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Components that have not been made fully shareable can be found in the [features
   * Availability editor
   * Score editor
   * Submission editor
+* Discover
+  * [Entitlement Rules](features/discover): Displays the rules for self enrollment and allows users to edit them
 
 ### Creating New Components
 

--- a/features/discover/README.md
+++ b/features/discover/README.md
@@ -1,0 +1,13 @@
+# Discover Foundation Components
+
+Components specific to the Discover feature.
+
+## d2l-discover-entitlement-rules
+
+Allows users to change whether a course is self-enrollable or not. Allows for choosing rules for which users will see courses in the Discover feature.
+
+### Example
+
+```html
+<d2l-discover-entitlement-rules href="${courseHref}" .token="${token}"></d2l-discover-entitlement-rules>
+```

--- a/features/discover/d2l-discover-entitlement-rules.js
+++ b/features/discover/d2l-discover-entitlement-rules.js
@@ -1,8 +1,8 @@
 import '@brightspace-ui-labs/checkbox-drawer/checkbox-drawer.js';
 import '@brightspace/discover-components/components/rule-picker-dialog.js';
-import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeDiscoverEntitlement } from './lang/localization.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
@@ -81,7 +81,7 @@ class EntitlementRules extends LocalizeDiscoverEntitlement(SkeletonMixin(Hyperme
 		`;
 	}
 
-	_onRuleConditionsChanged(e) {
+	_onRuleConditionsChanged() {
 		//todo: change the state from within the component instead of catching this event
 	}
 

--- a/features/discover/d2l-discover-entitlement-rules.js
+++ b/features/discover/d2l-discover-entitlement-rules.js
@@ -59,7 +59,7 @@ class EntitlementRules extends LocalizeDiscoverEntitlement(SkeletonMixin(Hyperme
 		return html`
 			<h4 class="d2l-body-small d2l-skeletize"><strong>${this.localize('text-title')}</strong></h4>
 			<d2l-labs-checkbox-drawer
-				?checked="${this.isSelfEnrollable}"
+				?checked="${this.isSelfEnrollable || (this.rules && this.rules.length)}"
 				label="${this.localize('label-checkbox')}"
 				description="${this.localize('text-checkbox-description')}"
 				class="d2l-skeletize">

--- a/features/discover/d2l-discover-entitlement-rules.js
+++ b/features/discover/d2l-discover-entitlement-rules.js
@@ -1,0 +1,89 @@
+import '@brightspace-ui-labs/checkbox-drawer/checkbox-drawer.js';
+import '@brightspace/discover-components/components/rule-picker-dialog.js';
+import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { LocalizeDiscoverEntitlement } from './lang/localization.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+
+const rels = Object.freeze({
+	selfAssignableClass: 'self-assignable',
+	rule: 'rule',
+	entitlementRules: 'entitlement-rules',
+	conditionType: 'condition-type',
+	conditionTypes: 'available-condition-types'
+});
+
+class EntitlementRules extends LocalizeDiscoverEntitlement(SkeletonMixin(HypermediaStateMixin(LitElement))) {
+	static get properties() {
+		return {
+			name: { type: String, observable: observableTypes.property },
+			isSelfEnrollable: { type: Boolean, observable: observableTypes.classes, method: (classes) => classes.includes(rels.selfAssignableClass) },
+			// rules: { observable: observableTypes.subEntities, rel: rels.rule, route: [
+			// 	{ observable: observableTypes.link, rel: rels.entitlementRules }
+			// ] },
+			conditionTypes: { observable: observableTypes.subEntities, rel: rels.conditionType, route: [
+				{ observable: observableTypes.link, rel: rels.conditionTypes }
+			]}
+		};
+	}
+
+	static get styles() {
+		return [ super.styles, bodySmallStyles, css`
+			h4.d2l-body-small,
+			h5.d2l-body-small {
+				color: var(--d2l-color-ferrite);
+				margin: 0.7rem 0;
+			}
+			h5.d2l-body-small + p {
+				margin-top: 0;
+			}
+		` ];
+	}
+
+	constructor() {
+		super();
+		this.skeleton = true;
+	}
+
+	get _loaded() {
+		return !this.skeleton;
+	}
+
+	set _loaded(loaded) {
+		this.skeleton = !loaded;
+	}
+
+	render() {
+		const typeList = this.conditionTypes?.map(conditionType => conditionType.properties.type);
+		return html`
+			<h4 class="d2l-body-small d2l-skeletize"><strong>${this.localize('text-title')}</strong></h4>
+			<d2l-labs-checkbox-drawer
+				?checked="${this.isSelfEnrollable}"
+				label="${this.localize('label-checkbox')}"
+				description="${this.localize('text-checkbox-description')}"
+				class="d2l-skeletize">
+			${this.rules && this.rules.length ? html`
+			<div class="d2l-body-small d2l-enrollment-rules">
+				<h5 class="d2l-body-small"><strong>${this.localize('text-rules')}</strong></h5>
+				<p>${this.localize('text-rules-description')}</p>
+				<!-- rules cards -->
+			</div>
+			` : null}
+			${typeList ? html`
+			<rule-picker-dialog
+				@rule-conditions-changed="${this._onRuleConditionsChanged}"
+				.conditionTypes="${typeList}"
+				default="${typeList[0]}"
+			></rule-picker-dialog>
+			` : null }
+			</d2l-labs-checkbox-drawer>
+		`;
+	}
+
+	_onRuleConditionsChanged(e) {
+		//todo: change the state from within the component instead of catching this event
+	}
+
+}
+customElements.define('d2l-discover-entitlement-rules', EntitlementRules);

--- a/features/discover/demo/condition-typea-values.json
+++ b/features/discover/demo/condition-typea-values.json
@@ -1,0 +1,5 @@
+{
+  "properties": {
+    "values": ["one", "two", "three", "four", "five"]
+  }
+}

--- a/features/discover/demo/condition-typeb-values.json
+++ b/features/discover/demo/condition-typeb-values.json
@@ -1,0 +1,5 @@
+{
+  "properties": {
+    "values": ["six", "sever", "eight", "nine", "ten"]
+  }
+}

--- a/features/discover/demo/condition-types.json
+++ b/features/discover/demo/condition-types.json
@@ -1,0 +1,35 @@
+{
+  "entities": [
+    {
+      "actions": [{
+        "name": "possible-values",
+        "href": "../demo/condition-typea-values.json",
+        "method": "POST"
+      }],
+      "properties": {
+        "type": "conditionTypeA"
+      },
+      "links": [
+        { "rel": ["self"], "href": "../demo/condition-type-a.json" }
+      ],
+      "rel": ["condition-type"]
+    },
+    {
+      "actions": [{
+        "name": "possible-values",
+        "href": "../demo/condition-typeb-values.json",
+        "method": "POST"
+      }],
+      "properties": {
+        "type": "conditionTypeB"
+      },
+      "links": [
+        { "rel": ["self"], "href": "../demo/condition-type-b.json" }
+      ],
+      "rel": ["condition-type"]
+    }
+  ],
+  "links": [
+    { "rel": ["self"], "href": "../demo/condition-types.json" }
+  ]
+}

--- a/features/discover/demo/course-entitlement-rules.json
+++ b/features/discover/demo/course-entitlement-rules.json
@@ -15,6 +15,6 @@
     }
   ],
   "links": [
-    { "rel": ["self"], "href": "../demo/course-enrollment-rules.json" }
+    { "rel": ["self"], "href": "../demo/course-entitlement-rules.json" }
   ]
 }

--- a/features/discover/demo/course-entitlement-rules.json
+++ b/features/discover/demo/course-entitlement-rules.json
@@ -1,0 +1,20 @@
+{
+  "entities": [
+    {
+      "rel": ["rule"],
+      "entities": [
+        {
+          "rel": ["condition"],
+          "properties": {
+            "type": "TypeX",
+            "values": [ "value1", "value2" ]
+          }
+        }
+      ],
+      "links": [ { "rel": ["matching-users"], "href": "../demo/matching-users.json"} ]
+    }
+  ],
+  "links": [
+    { "rel": ["self"], "href": "../demo/course-enrollment-rules.json" }
+  ]
+}

--- a/features/discover/demo/course.json
+++ b/features/discover/demo/course.json
@@ -1,0 +1,24 @@
+{
+  "class": [
+    "named-entity",
+    "describable-entity",
+    "draft-published-entity",
+    "published",
+    "active",
+    "course-offering",
+    "self-assignable"
+  ],
+  "properties": {
+    "name": "Course",
+    "code": "C1",
+    "startDate": null,
+    "endDate": null,
+    "isActive": true,
+    "description": ""
+  },
+  "links": [
+    { "rel": [ "self" ], "href": "../demo/course.json" },
+    { "rel": [ "entititlement-rules" ], "href": "../demo/course-entititlement-rules.json" },
+    { "rel": [ "available-condition-types" ], "href": "../demo/condition-types.json" }
+  ]
+}

--- a/features/discover/demo/course.json
+++ b/features/discover/demo/course.json
@@ -18,7 +18,7 @@
   },
   "links": [
     { "rel": [ "self" ], "href": "../demo/course.json" },
-    { "rel": [ "entititlement-rules" ], "href": "../demo/course-entititlement-rules.json" },
+    { "rel": [ "entitlement-rules" ], "href": "../demo/course-entitlement-rules.json" },
     { "rel": [ "available-condition-types" ], "href": "../demo/condition-types.json" }
   ]
 }

--- a/features/discover/demo/d2l-discover-entitlement-rules.html
+++ b/features/discover/demo/d2l-discover-entitlement-rules.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../d2l-discover-entitlement-rules.js';
+		</script>
+		<title>d2l-discover-entitlement-rules</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body>
+		<d2l-demo-page page-title="d2l-discover-entitlement-rules">
+			<h2>d2l-discover-entitlement-rules</h2>
+			<d2l-demo-snippet>
+				<d2l-discover-entitlement-rules href="./course.json" token="cake"></d2l-discover-entitlement-rules>
+			</d2l-demo-snippet>
+
+		</d2l-demo-page>
+	</body>
+</html>

--- a/features/discover/demo/matching-users.json
+++ b/features/discover/demo/matching-users.json
@@ -1,0 +1,49 @@
+{
+  "class": ["collection", "users"],
+  "entitites": [
+    {
+      "class": ["user"],
+      "properties": {
+        "displayName": "Zina Ramirez",
+        "firstName": "Zina",
+        "lastName": "Ramirez",
+        "userId": 100
+      },
+      "links": [
+        { "rel": ["self"], "href": "../demo/user-1.json" },
+        { "rel": ["image"], "href": "../demo/user-image.png" }
+      ]
+    },
+    {
+      "class": ["user"],
+      "properties": {
+        "displayName": "Brad Hamelin",
+        "firstName": "Bradley",
+        "lastName": "Hamelin",
+        "userId": 90
+      },
+      "links": [
+        { "rel": ["self"], "href": "../demo/user-2.json" },
+        { "rel": ["image"], "href": "../demo/user-image2.png" }
+      ]
+    },
+    {
+      "class": ["user"],
+      "properties": {
+        "displayName": "Alex Kobets",
+        "firstName": "Alex",
+        "lastName": "Kobets",
+        "userId": 20
+      },
+      "links": [
+        { "rel": ["self"], "href": "../demo/user-3.json" }
+      ]
+    }
+  ],
+  "properties": {
+    "total": 120
+  },
+  "links": [
+    { "rel": ["self"], "href": "../demo/matching-users.json" }
+  ]
+}

--- a/features/discover/lang/en.js
+++ b/features/discover/lang/en.js
@@ -1,0 +1,8 @@
+/* eslint quotes: 0 */
+export default {
+	"text-title": "Discover", // The title for Discover options
+	"label-checkbox": "Make this course available in Discover so Learners can self-enroll", // label for the discover checkbox
+	"text-checkbox-description": "Inactive courses will not be included in Discover", // extra info for discover checkbox
+	"text-rules": "Enrollment Rules", // title for enrollment rules options
+	"text-rules-description": "To self-enroll in this course, users must match one or more of these rules.", // description for enrollment rules
+};

--- a/features/discover/lang/localization.js
+++ b/features/discover/lang/localization.js
@@ -1,0 +1,65 @@
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+export const LocalizeDiscoverEntitlement = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+		let translations;
+		for await (const lang of langs) {
+			switch (lang) {
+				case 'ar':
+					translations = await import('./ar.js');
+					break;
+				case 'da-dk':
+					translations = await import('./da-dk.js');
+					break;
+				case 'de':
+					translations = await import('./de.js');
+					break;
+				case 'en':
+					translations = await import('./en.js');
+					break;
+				case 'es':
+					translations = await import('./es.js');
+					break;
+				case 'fr':
+					translations = await import('./fr.js');
+					break;
+				case 'ja':
+					translations = await import('./ja.js');
+					break;
+				case 'ko':
+					translations = await import('./ko.js');
+					break;
+				case 'nl':
+					translations = await import('./nl.js');
+					break;
+				case 'pt':
+					translations = await import('./pt.js');
+					break;
+				case 'sv':
+					translations = await import('./sv.js');
+					break;
+				case 'tr':
+					translations = await import('./tr.js');
+					break;
+				case 'zh-tw':
+					translations = await import('./zh-tw.js');
+					break;
+				case 'zh':
+					translations = await import('./zh.js');
+					break;
+			}
+			if (translations && translations.default) {
+				return {
+					language: lang,
+					resources: translations.default
+				};
+			}
+		}
+		translations = await import('./en.js');
+		return {
+			language: 'en',
+			resources: translations.default
+		};
+	}
+};

--- a/index.html
+++ b/index.html
@@ -32,6 +32,12 @@
 				<li><a href="demo/activity/d2l-activity-name.html">Name</a></li>
 				<li><a href="demo/activity/d2l-activity-type.html">Type</a></li>
 			</ul>
+
+			<h3>Features</h3>
+			<h4>Discover</h4>
+			<ul>
+				<li><a href="features/discover/demo/d2l-discover-entitlement-rules.html">Entitlement Rules</a></li>
+			</ul>
 		</d2l-demo-page>
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   },
   "dependencies": {
     "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",
+    "@brightspace-ui-labs/checkbox-drawer": "git+https://github.com/BrightspaceUILabs/checkbox-drawer.git",
     "@brightspace-ui-labs/list-item-accumulator": "^1",
     "@brightspace-ui/core": "^1",
+    "@brightspace/discover-components": "git+https://github.com/Brightspace/Discover-Components.git",
     "d2l-activities": "BrightspaceHypermediaComponents/activities.git#semver:^3",
     "d2l-course-image": "github:Brightspace/course-image#semver:^3",
     "lit-element": "^2",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   },
   "dependencies": {
     "@brightspace-hmc/foundation-engine": "github:BrightspaceHypermediaComponents/foundation-engine#semver:^0",
-    "@brightspace-ui-labs/checkbox-drawer": "git+https://github.com/BrightspaceUILabs/checkbox-drawer.git",
+    "@brightspace-ui-labs/checkbox-drawer": "github:BrightspaceUILabs/checkbox-drawer#semver:^1",
     "@brightspace-ui-labs/list-item-accumulator": "^1",
     "@brightspace-ui/core": "^1",
-    "@brightspace/discover-components": "git+https://github.com/Brightspace/Discover-Components.git",
+    "@brightspace/discover-components": "github:Brightspace/Discover-Components#semver:^1",
     "d2l-activities": "BrightspaceHypermediaComponents/activities.git#semver:^3",
     "d2l-course-image": "github:Brightspace/course-image#semver:^3",
     "lit-element": "^2",


### PR DESCRIPTION
## Context
[US123170](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F462626337568&fdp=true?fdp=true)
The first of what will likely be several small-ish PRs to bring the new Discover entitlement components into the fold.

- Adds the `d2l-discover-entitlement-rules` component
- Brings together two UI components: the checkbox drawer and the rule-picker
- Adds a demo that includes mock data showing what the API should look like
![Kapture 2021-02-18 at 14 20 16](https://user-images.githubusercontent.com/2412740/108543161-b452c300-72b2-11eb-8583-d08f37368f4c.gif)

## Quality
- Run `npm start` and visit the demo page to manually test

## Coming Soon
- The `rule-picker-dialog` and `rule-picker` components will be migrated to `Foundations` because they are heavily data-oriented.