### PR TITLE
feat: add secondary slot ui card and use it for learning path

### DIFF
--- a/components/activity/editor/collection/d2l-activity-card-learning-path.js
+++ b/components/activity/editor/collection/d2l-activity-card-learning-path.js
@@ -1,0 +1,33 @@
+
+import '@brightspace-ui-labs/accordion/accordion-collapse.js';
+import './d2l-activity-editor-secondary-card.js';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+
+class ActivityEditorLearningPathCard extends LitElement {
+
+	static get properties() {
+		return {
+			titleText: { type: String, attribute: 'title-text' },
+			bodyText: { type: String, attribute: 'body-text' },
+			collapsable: { type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return [labelStyles, css`
+			:host([hidden]) {
+				display: none;
+			}
+		`];
+	}
+
+	render() {
+		return html`
+		<d2l-activity-secondary-card title-text="Additional Identification">
+		</d2l-activity-secondary-card>`;
+	}
+}
+
+customHypermediaElement('d2l-activity-card-learning-path', ActivityEditorLearningPathCard);

--- a/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
+++ b/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
@@ -1,10 +1,18 @@
 
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
-import { css, LitElement } from 'lit-element/lit-element';
-import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 
 class ActivityEditorSecondaryCard extends LitElement {
+
+	static get properties() {
+		return {
+			titleText: { type: String, attribute: 'title-text' },
+			bodyText: { type: String, attribute: 'body-text' },
+			collapsable: { type: Boolean }
+		};
+	}
 
 	static get styles() {
 		return [labelStyles, css`
@@ -20,22 +28,51 @@ class ActivityEditorSecondaryCard extends LitElement {
 				padding: 20px;
 				padding-top: 0;
 			}
+			.d2l-activity-editor-card {
+				display: grid;
+				grid-template-rows: [start header] auto [content] auto [end];
+			}
+			::slotted([slot=header]) {
+				grid-row: header;
+			}
+			::slotted([slot=content]) {
+				grid-row: content;
+			}
 		`];
 	}
 
 	render() {
+		return this.collapsable ? this._renderCollapsable() : this._renderDefault();
+
+	}
+
+	_renderDefault() {
 		return html`
+			<span slot="header">
+			<h3>
+			${this.titleText}
+			</h3>
+			<hr>
+			</span>
+			<span class="content">
+			${this.bodyText}
+			</span>`;
+	}
+
+	_renderCollapsable() {
+		return html`<d2l-labs-accordion-collapse flex>
 		<span slot="header">
 		<h3>
-		Additional Identification
+		${this.titleText}
 		</h3>
 		<hr>
 		</span>
 		<span class="content">
-		Blah blah blah
+		${this.bodyText}
 		</span>
+		</d2l-labs-accordion-collapse>
 		`;
 	}
 }
 
-customHypermediaElement('d2l-activity-editor-card', ActivityEditorSecondaryCard);
+customHypermediaElement('d2l-activity-secondary-card', ActivityEditorSecondaryCard);

--- a/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
+++ b/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
@@ -14,35 +14,28 @@ class ActivityEditorSecondaryCard extends LitElement {
 			:host {
 				display: flex;
 				flex-direction: column;
+				background: var(--d2l-color-white);
+				border-radius: 8px;
+				margin-bottom: 10px;
+				padding: 20px;
+				padding-top: 0;
 			}
 		`];
 	}
 
 	render() {
-
 		return html`
-		<d2l-activity-accordion-collapse header-border>
 		<span slot="header">
 		<h3>
 		Additional Identification
 		</h3>
+		<hr>
 		</span>
-		</d2l-activity-accordion-collapse>
+		<span class="content">
+		Blah blah blah
+		</span>
 		`;
 	}
 }
 
 customHypermediaElement('d2l-activity-editor-card', ActivityEditorSecondaryCard);
-
-/*
-<d2l-activity-accordion-collapse flex header-border>
-		<span slot="header">
-			<h3>
-			Additional Identification
-			</h3>
-		</span>
-		<span slot="content">
-		Components go here.
-		</span>
-		</d2l-activity-accordion-collapse>
-*/

--- a/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
+++ b/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
@@ -1,11 +1,10 @@
 
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
-import '@brightspace-ui-labs/accordion/accordion.js';
 import { css, LitElement } from 'lit-element/lit-element';
 import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 
-class ActivityAvailabilityDatesEditor extends LitElement {
+class ActivityEditorSecondaryCard extends LitElement {
 
 	static get styles() {
 		return [labelStyles, css`
@@ -22,17 +21,28 @@ class ActivityAvailabilityDatesEditor extends LitElement {
 	render() {
 
 		return html`
-		<d2l-labs-accordion-collapse
-		flex header-border>
+		<d2l-activity-accordion-collapse header-border>
 		<span slot="header">
-			Words!
+		<h3>
+		Additional Identification
+		</h3>
 		</span>
-		<ul slot="summary">
-			More words!
-		</ul>
-		</d2l-labs-accordion-collapse>
+		</d2l-activity-accordion-collapse>
 		`;
 	}
 }
 
-customHypermediaElement('d2l-activity-editor-card', ActivityAvailabilityDatesEditor);
+customHypermediaElement('d2l-activity-editor-card', ActivityEditorSecondaryCard);
+
+/*
+<d2l-activity-accordion-collapse flex header-border>
+		<span slot="header">
+			<h3>
+			Additional Identification
+			</h3>
+		</span>
+		<span slot="content">
+		Components go here.
+		</span>
+		</d2l-activity-accordion-collapse>
+*/

--- a/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
+++ b/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
@@ -1,0 +1,38 @@
+
+import '@brightspace-ui-labs/accordion/accordion-collapse.js';
+import '@brightspace-ui-labs/accordion/accordion.js';
+import { css, LitElement } from 'lit-element/lit-element';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+
+class ActivityAvailabilityDatesEditor extends LitElement {
+
+	static get styles() {
+		return [labelStyles, css`
+			:host([hidden]) {
+				display: none;
+			}
+			:host {
+				display: flex;
+				flex-direction: column;
+			}
+		`];
+	}
+
+	render() {
+
+		return html`
+		<d2l-labs-accordion-collapse
+		flex header-border>
+		<span slot="header">
+			Words!
+		</span>
+		<ul slot="summary">
+			More words!
+		</ul>
+		</d2l-labs-accordion-collapse>
+		`;
+	}
+}
+
+customHypermediaElement('d2l-activity-editor-card', ActivityAvailabilityDatesEditor);

--- a/components/activity/editor/collection/d2l-activity-editor-sidebar-collection.js
+++ b/components/activity/editor/collection/d2l-activity-editor-sidebar-collection.js
@@ -27,13 +27,6 @@ class ActivityCollectionEditorSidebar extends HypermediaStateMixin(LitElement) {
 			:host([hidden]) {
 				display: none;
 			}
-			:host > * {
-				background: var(--d2l-color-white);
-				border-radius: 8px;
-				margin-bottom: 10px;
-				padding: 20px;
-				padding-top: 0;
-			}
 			`
 		];
 	}

--- a/components/activity/editor/collection/d2l-activity-editor-sidebar-collection.js
+++ b/components/activity/editor/collection/d2l-activity-editor-sidebar-collection.js
@@ -1,0 +1,49 @@
+import '@brightspace-ui-labs/accordion/accordion-collapse.js';
+import '@brightspace-ui-labs/accordion/accordion.js';
+import './d2l-activity-editor-secondary-card.js';
+import { css, LitElement } from 'lit-element/lit-element.js';
+import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+
+const rels = Object.freeze({
+	specialization: 'https://api.brightspace.com/rels/specialization'
+});
+
+class ActivityCollectionEditorSidebar extends HypermediaStateMixin(LitElement) {
+
+	static get properties() {
+		return {
+			_specializationHref: { type: String, observable: observableTypes.link, rel: rels.specialization }
+		};
+	}
+	static get styles() {
+
+		return [
+			css`
+			:host {
+				background: var(--d2l-color-gypsum);
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			:host > * {
+				background: var(--d2l-color-white);
+				border-radius: 8px;
+				margin-bottom: 10px;
+				padding: 20px;
+				padding-top: 0;
+			}
+			`
+		];
+	}
+
+	render() {
+		return html`
+		<d2l-activity-editor-card>
+		</d2l-activity-editor-card>
+		`;
+	}
+}
+
+customHypermediaElement('d2l-activity-editor-sidebar-collection', ActivityCollectionEditorSidebar, 'd2l-activity-editor-sidebar', [['activity-collection'], ['learning-path']]);

--- a/components/activity/editor/collection/d2l-activity-editor-sidebar-learning-path.js
+++ b/components/activity/editor/collection/d2l-activity-editor-sidebar-learning-path.js
@@ -1,9 +1,7 @@
-import '@brightspace-ui-labs/accordion/accordion-collapse.js';
-import '@brightspace-ui-labs/accordion/accordion.js';
-import './d2l-activity-editor-secondary-card.js';
-import { css, LitElement } from 'lit-element/lit-element.js';
-import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import './d2l-activity-card-learning-path.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 
 const rels = Object.freeze({
 	specialization: 'https://api.brightspace.com/rels/specialization'
@@ -13,6 +11,8 @@ class ActivityCollectionEditorSidebar extends HypermediaStateMixin(LitElement) {
 
 	static get properties() {
 		return {
+			href: { type: String, reflect: true },
+			token: { type: String },
 			_specializationHref: { type: String, observable: observableTypes.link, rel: rels.specialization }
 		};
 	}
@@ -33,10 +33,9 @@ class ActivityCollectionEditorSidebar extends HypermediaStateMixin(LitElement) {
 
 	render() {
 		return html`
-		<d2l-activity-editor-card>
-		</d2l-activity-editor-card>
+		<d2l-activity-card-learning-path href="${this.href}" .token="${this.token}" }></d2l-activity-card-learning-path>
 		`;
 	}
 }
 
-customHypermediaElement('d2l-activity-editor-sidebar-collection', ActivityCollectionEditorSidebar, 'd2l-activity-editor-sidebar', [['activity-collection'], ['learning-path']]);
+customHypermediaElement('d2l-activity-editor-sidebar-learning-path', ActivityCollectionEditorSidebar, 'd2l-activity-editor-sidebar', [['activity-collection'], ['learning-path']]);

--- a/components/activity/editor/d2l-activity-editor-sidebar.js
+++ b/components/activity/editor/d2l-activity-editor-sidebar.js
@@ -1,1 +1,3 @@
 import './assignment/d2l-activity-editor-sidebar-assignment.js';
+import './collection/d2l-activity-editor-sidebar-collection.js';
+

--- a/components/activity/editor/d2l-activity-editor-sidebar.js
+++ b/components/activity/editor/d2l-activity-editor-sidebar.js
@@ -1,3 +1,3 @@
 import './assignment/d2l-activity-editor-sidebar-assignment.js';
-import './collection/d2l-activity-editor-sidebar-collection.js';
+import './collection/d2l-activity-editor-sidebar-learning-path.js';
 


### PR DESCRIPTION
### Context:
[US122674](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F458814721568&fdp=true?fdp=true)
We're adding the secondary pane for the org code. This is creating a ui component for the cards we will use and implementing a hypermedia component for the card.

### Quality:
Tested with local bsi in sitelord.

![secondary-card](https://user-images.githubusercontent.com/69812595/109058864-8524c300-76b1-11eb-82bb-b0a47a16f706.png)

