### PR TITLE
doc: adding demo pages for collection editor components

### DIFF
--- a/components/activity/editor/collection/d2l-activity-editor-sidebar-learning-path.js
+++ b/components/activity/editor/collection/d2l-activity-editor-sidebar-learning-path.js
@@ -33,7 +33,7 @@ class ActivityCollectionEditorSidebar extends HypermediaStateMixin(LitElement) {
 
 	render() {
 		return html`
-		<d2l-activity-card-learning-path href="${this.href}" .token="${this.token}" }></d2l-activity-card-learning-path>
+		<d2l-activity-card-learning-path href="${this.href}" .token="${this.token}"></d2l-activity-card-learning-path>
 		`;
 	}
 }

--- a/demo/data/base/add-existing-activity.json
+++ b/demo/data/base/add-existing-activity.json
@@ -34,7 +34,7 @@
             "https://activities.api.brightspace.com/rels/activity-usage",
             "self"
           ],
-          "href": "../../demo/data/base/courses/course-offering-1.json"
+          "href": "../../../demo/data/base/courses/course-offering-1.json"
         }
       ]
     },
@@ -68,7 +68,7 @@
             "https://activities.api.brightspace.com/rels/activity-usage",
             "self"
           ],
-          "href": "../../demo/data/base/courses/course-offering-2.json"
+          "href": "../../../demo/data/base/courses/course-offering-2.json"
         }
       ]
     },
@@ -102,7 +102,7 @@
             "https://activities.api.brightspace.com/rels/activity-usage",
             "self"
           ],
-          "href": "../../demo/data/base/courses/course-offering-3.json"
+          "href": "../../../demo/data/base/courses/course-offering-3.json"
         }
       ]
     }

--- a/demo/data/base/collection-full.json
+++ b/demo/data/base/collection-full.json
@@ -16,13 +16,13 @@
           "rel": [
             "self"
           ],
-          "href": "data/base/courses/course-offering-1.json"
+          "href": "../../../demo/data/base/courses/course-offering-1.json"
         },
         {
           "rel": [
             "https://activities.api.brightspace.com/rels/activity-usage"
           ],
-          "href": "data/base/courses/course-offering-1.json"
+          "href": "../../../demo/data/base/courses/course-offering-1.json"
         },
         {
           "rel": [
@@ -55,13 +55,13 @@
           "rel": [
             "self"
           ],
-          "href": "data/base/courses/course-offering-2.json"
+          "href": "../../../demo/data/base/courses/course-offering-2.json"
         },
         {
           "rel": [
             "https://activities.api.brightspace.com/rels/activity-usage"
           ],
-          "href": "data/base/courses/course-offering-2.json"
+          "href": "../../../demo/data/base/courses/course-offering-2.json"
         },
         {
           "rel": [
@@ -86,7 +86,7 @@
       "method": "POST"
     },
     {
-      "href": "../../demo/data/base/add-existing-activity.json",
+      "href": "../../../demo/data/base/add-existing-activity.json",
       "name": "start-add-existing-activity",
       "method": "GET"
     },

--- a/demo/data/base/existing-learning-path.json
+++ b/demo/data/base/existing-learning-path.json
@@ -156,7 +156,7 @@
       "rel": [
         "https://activities.api.brightspace.com/rels/activity-collection"
       ],
-      "href": "../../demo/data/base/collection-full.json"
+      "href": "../../../demo/data/base/collection-full.json"
     },
     {
       "rel": [

--- a/demo/editor/d2l-activity-editor-footer.html
+++ b/demo/editor/d2l-activity-editor-footer.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../../components/activity/editor/d2l-activity-editor-footer.js';
+		</script>
+		<title>Learning Path Editor</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body>
+		<d2l-demo-page page-title="Editor Header">
+			<h2>Hidden Learning Path</h2>
+			<d2l-demo-snippet>
+				<d2l-activity-editor-footer href="../data/base/new-learning-path.json" token="cake"></d2l-activity-editor-footer>
+			</d2l-demo-snippet>
+
+			<h2>Visible Learning Path</h2>
+			<d2l-demo-snippet>
+				<d2l-activity-editor-footer href="../data/base/existing-learning-path.json" token="cake"></d2l-activity-editor-footer>
+			</d2l-demo-snippet>
+		</d2l-demo-page>
+	</body>
+</html>

--- a/demo/editor/d2l-activity-editor-header.html
+++ b/demo/editor/d2l-activity-editor-header.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../components/activity/editor/d2l-activity-editor-header.js';
+		</script>
+		<title>Learning Path Editor</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body>
+		<d2l-demo-page page-title="Editor Header">
+			<h2>New Learning Path</h2>
+			<d2l-demo-snippet>
+				<d2l-activity-editor-header href="../data/base/new-learning-path.json" token="cake"></d2l-activity-editor-header>
+			</d2l-demo-snippet>
+
+			<h2>Existing Learning Path</h2>
+			<d2l-demo-snippet>
+				<d2l-activity-editor-header href="../data/base/existing-learning-path.json" token="cake"></d2l-activity-editor-header>
+			</d2l-demo-snippet>
+		</d2l-demo-page>
+	</body>
+</html>

--- a/demo/editor/d2l-activity-editor-main.html
+++ b/demo/editor/d2l-activity-editor-main.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../components/activity/editor/collection/d2l-activity-editor-main-collection.js';
+		</script>
+		<title>Learning Path Editor</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body>
+		<d2l-demo-page page-title="Editor Main">
+			<h2>New Learning Path</h2>
+			<d2l-demo-snippet>
+				<d2l-activity-editor-main-collection href="../data/base/new-learning-path.json" token="cake"></d2l-activity-editor-main-collection>
+			</d2l-demo-snippet>
+
+			<h2>Existing Learning Path</h2>
+			<d2l-demo-snippet>
+				<d2l-activity-editor-main-collection href="../data/base/existing-learning-path.json" token="cake"></d2l-activity-editor-main-collection>
+			</d2l-demo-snippet>
+		</d2l-demo-page>
+	</body>
+</html>

--- a/demo/editor/d2l-activity-editor-sidebar.html
+++ b/demo/editor/d2l-activity-editor-sidebar.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link rel="stylesheet" href="/node_modules/@brightspace-ui/core/components/demo/styles.css" type="text/css">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module">
+			import '@brightspace-ui/core/components/demo/demo-page.js';
+			import '../../components/activity/editor/d2l-activity-editor-sidebar.js';
+		</script>
+		<title>Learning Path Editor</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta http-equiv="X-UA-Compatible" content="ie=edge">
+		<meta charset="UTF-8">
+	</head>
+	<body>
+		<d2l-demo-page page-title="Editor Sidebar">
+			<h2>Existing Learning Path</h2>
+			<d2l-demo-snippet>
+				<d2l-activity-editor-sidebar-learning-path href="../data/base/existing-learning-path.json" token="cake"></d2l-activity-editor-sidebar-learning-path>
+			</d2l-demo-snippet>
+		</d2l-demo-page>
+	</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,14 @@
 			<h3>Editor</h3>
 			<ul>
 				<li><a href="demo/d2l-activity-editor.html">Learning Path</a></li>
-
+			</ul>
+			<h4>Editor Components</h4>
+			<ul>
+				<li><a href="demo/editor/d2l-activity-editor-header.html">Header</a></li>
+				<li><a href="demo/editor/d2l-activity-editor-main.html">Main</a></li>
+				<li><a href="demo/editor/d2l-activity-editor-sidebar.html">Sidebar</a></li>
+				<li><a href="demo/editor/d2l-activity-editor-footer.html">Footer</a></li>
+			</ul>
 			<h3>Features</h3>
 			<h4>Discover</h4>
 			<ul>


### PR DESCRIPTION
### Context:
[US122506](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F457719949704&fdp=true?fdp=true)
We have a bunch of components for collection editor. We want to show them off individually in demo pages.

### Quality:
Tests demo pages locally.
The sidebar needs to be cleaned up