### PR TITLE
fix: change divider colour for caketray to match design

### DIFF
--- a/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
+++ b/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
@@ -41,7 +41,7 @@ class ActivityEditorSecondaryCard extends LitElement {
 				grid-row: content;
 			}
 			hr.d2l-split {
-				border-bottom: solid 1px redvar(--d2l-color-corundum)
+				border-bottom: solid 1px var(--d2l-color-corundum)
 			}
 		`];
 	}

--- a/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
+++ b/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
@@ -40,23 +40,21 @@ class ActivityEditorSecondaryCard extends LitElement {
 			::slotted([slot=content]) {
 				grid-row: content;
 			}
-			hr.split {
-				border-bottom: solid 1px var(--d2l-color-corundum)
+			hr.d2l-split {
+				border-bottom: solid 1px redvar(--d2l-color-corundum)
 			}
 		`];
 	}
 
 	render() {
 		return this.collapsable ? this._renderCollapsable() : this._renderDefault();
-
 	}
 
 	_renderCollapsable() {
 		return html`
-		<d2l-labs-accordion-collapse flex>
+		<d2l-labs-accordion-collapse flex header-border>
 			<span slot="header">
 				<h3>${this.titleText}</h3>
-				<hr class="split">
 			</span>
 			<span class="content">${this.bodyText}</span>
 			<slot name="card-content"></slot>
@@ -68,7 +66,7 @@ class ActivityEditorSecondaryCard extends LitElement {
 		return html`
 			<span slot="header">
 				<h3>${this.titleText}</h3>
-				<hr>
+				<hr class="d2l-split">
 			</span>
 			<span class="content">${this.bodyText}</span>
 			<slot name="card-content"></slot>

--- a/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
+++ b/components/activity/editor/collection/d2l-activity-editor-secondary-card.js
@@ -40,6 +40,9 @@ class ActivityEditorSecondaryCard extends LitElement {
 			::slotted([slot=content]) {
 				grid-row: content;
 			}
+			hr.split {
+				border-bottom: solid 1px var(--d2l-color-corundum)
+			}
 		`];
 	}
 
@@ -53,7 +56,7 @@ class ActivityEditorSecondaryCard extends LitElement {
 		<d2l-labs-accordion-collapse flex>
 			<span slot="header">
 				<h3>${this.titleText}</h3>
-				<hr>
+				<hr class="split">
 			</span>
 			<span class="content">${this.bodyText}</span>
 			<slot name="card-content"></slot>


### PR DESCRIPTION
### Context: 
[US122674](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F458814721568&fdp=true?fdp=true)
The horizontal line is not the right colour currently. This updates it.