### PR TITLE
fix: Add sample button for legacy page test

### DIFF
--- a/features/discover/d2l-discover-sample-button.js
+++ b/features/discover/d2l-discover-sample-button.js
@@ -1,0 +1,35 @@
+/**
+ * This button is designed for demoing with a legacy page and will be removed once the rules
+ * component is integrated into the Course Offering Information page
+ */
+import '@brightspace-ui/core/components/button/button.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { LocalizeDiscoverEntitlement } from './lang/localization.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+
+class SampleButton extends LocalizeDiscoverEntitlement(RtlMixin(LitElement)) {
+
+
+	static get properties() {
+		return {
+			text: { type: String }
+		};
+	}
+
+	render() {
+		return html`
+			<d2l-button @click="${this._onClick}">${this.text}</d2l-button>
+		`;
+	}
+
+	_onClick() {
+		const event = new CustomEvent('d2l-sample-button-click', {
+			bubbles: true,
+			detail: {
+				value: this.text
+			}
+		});
+		this.dispatchEvent(event);
+	}
+}
+customElements.define('d2l-discover-sample-button', SampleButton);

--- a/features/discover/d2l-discover-sample-button.js
+++ b/features/discover/d2l-discover-sample-button.js
@@ -9,7 +9,6 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 class SampleButton extends LocalizeDiscoverEntitlement(RtlMixin(LitElement)) {
 
-
 	static get properties() {
 		return {
 			text: { type: String }

--- a/features/discover/demo/d2l-discover-rules.html
+++ b/features/discover/demo/d2l-discover-rules.html
@@ -6,6 +6,7 @@
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../d2l-discover-rules.js';
+			import '../d2l-discover-sample-button.js';
 		</script>
 		<title>d2l-discover-rules</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -17,6 +18,11 @@
 			<h2>d2l-discover-rules</h2>
 			<d2l-demo-snippet>
 				<d2l-discover-rules href="./course.json" token="cake"></d2l-discover-rules>
+			</d2l-demo-snippet>
+
+			<h2>d2l-discover-sample-button</h2>
+			<d2l-demo-snippet>
+				<d2l-discover-sample-button text="I am a button"></d2l-discover-sample-button>
 			</d2l-demo-snippet>
 
 		</d2l-demo-page>


### PR DESCRIPTION
## Context
[US123769](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F480099321508&fdp=true&fdp=true?fdp=true)

Attempting to include a bare basic webcomponent in a legacy page via the "double adaptor" strategy @BhamelinD2L has talked about. See story for details.

## Quality
Added to demo page but tests unnecessary since this is a temporary component. `fix` prefix is to make sure we bump the version.