### PR TITLE
fix: add aria-label to code input

### DIFF
--- a/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
+++ b/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
@@ -3,6 +3,7 @@ import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css,  LitElement } from 'lit-element/lit-element.js';
 import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
+import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId';
 import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 
@@ -41,21 +42,23 @@ class ActivityCodeEditorLearningPath extends LocalizeDynamicMixin(HypermediaStat
 	constructor() {
 		super();
 		this.defaultLearningPathCode = 'LP';
+		this._codeId = getUniqueId();
 	}
 
 	render() {
 		return html`
-			<label>
-				<span class="d2l-input-label">${this.localize('label-code-lp')}</span>
+			<label class="d2l-input-label" for="${this._codeId}">
+				<span>${this.localize('label-code-lp')}</span>
 				<div class="d2l-activity-code-editor-description">${this.localize('text-code-description-lp')}</div>
-				<d2l-input-text
-					@input="${this._onInputCode}"
-					placeholder="${this.defaultLearningPathCode}"
-					value="${this.code}"
-					?skeleton="${!this._loaded}"
-					maxlength=50
-				></d2l-input-text>
 			</label>
+			<d2l-input-text
+				aria-label="textfield ${this.localize('label-code-lp')} ${this.localize('text-code-description-lp')} ${this.code}"
+				id="${this._codeId}"
+				@input="${this._onInputCode}"
+				value="${this.code}"
+				?skeleton="${!this._loaded}"
+				maxlength=50
+			></d2l-input-text>
 		`;
 	}
 

--- a/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
+++ b/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
@@ -3,7 +3,6 @@ import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css,  LitElement } from 'lit-element/lit-element.js';
 import { customHypermediaElement, html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
-import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId';
 import { inputLabelStyles } from '@brightspace-ui/core/components/inputs/input-label-styles.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 
@@ -42,18 +41,18 @@ class ActivityCodeEditorLearningPath extends LocalizeDynamicMixin(HypermediaStat
 	constructor() {
 		super();
 		this.defaultLearningPathCode = 'LP';
-		this._codeId = getUniqueId();
 	}
 
 	render() {
 		return html`
-			<label class="d2l-input-label" for="${this._codeId}">
+			<label class="d2l-input-label">
 				<span>${this.localize('label-code-lp')}</span>
 				<div class="d2l-activity-code-editor-description">${this.localize('text-code-description-lp')}</div>
 			</label>
 			<d2l-input-text
-				aria-label="textfield ${this.localize('label-code-lp')} ${this.localize('text-code-description-lp')} ${this.code}"
-				id="${this._codeId}"
+				label="textfield ${this.localize('label-code-lp')}"
+				description="${this.localize('text-code-description-lp')}"
+				label-hidden
 				@input="${this._onInputCode}"
 				value="${this.code}"
 				?skeleton="${!this._loaded}"

--- a/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
+++ b/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
@@ -45,10 +45,10 @@ class ActivityCodeEditorLearningPath extends LocalizeDynamicMixin(HypermediaStat
 
 	render() {
 		return html`
-			<label class="d2l-input-label">
+			<div class="d2l-input-label">
 				<span>${this.localize('label-code-lp')}</span>
 				<div class="d2l-activity-code-editor-description">${this.localize('text-code-description-lp')}</div>
-			</label>
+			</div>
 			<d2l-input-text
 				label="textfield ${this.localize('label-code-lp')}"
 				description="${this.localize('text-code-description-lp')}"

--- a/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
+++ b/components/activity/code/custom/d2l-activity-code-editor-learning-path.js
@@ -46,8 +46,8 @@ class ActivityCodeEditorLearningPath extends LocalizeDynamicMixin(HypermediaStat
 	render() {
 		return html`
 			<div class="d2l-input-label">
-				<span>${this.localize('label-code-lp')}</span>
-				<div class="d2l-activity-code-editor-description">${this.localize('text-code-description-lp')}</div>
+				<span aria-hidden="true">${this.localize('label-code-lp')}</span>
+				<div class="d2l-activity-code-editor-description" aria-hidden="true">${this.localize('text-code-description-lp')}</div>
 			</div>
 			<d2l-input-text
 				label="textfield ${this.localize('label-code-lp')}"


### PR DESCRIPTION
https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F459180378604

```Context```
Screen reader was not matching expectation in test docs

```Quality```
screen reader should read textfield {label} {description} {value}
tested using NVDA