### PR TITLE
fix: demo data for editor

### DIFF
--- a/demo/data/base/new-learning-path.json
+++ b/demo/data/base/new-learning-path.json
@@ -24,6 +24,13 @@
     },
     {
       "rel": [
+        "https://api.brightspace.com/rels/organization",
+        "https://api.brightspace.com/rels/specialization"
+      ],
+      "href": "/demo/data/base/new-learning-path.json"
+    },
+    {
+      "rel": [
         "https://activities.api.brightspace.com/rels/user-activity-usage",
         "https://activities.api.brightspace.com/rels/my-activity-usage"
       ],


### PR DESCRIPTION
```Context```
Organization and specialization rels were removed from the new learning path json, this caused the editor demo to not load properly. 

```Quality```
Editor demo now populates the properties