### PR TITLE
fix: Fixing rule picker cancel

### DIFF
--- a/features/discover/d2l-discover-rule-picker-dialog.js
+++ b/features/discover/d2l-discover-rule-picker-dialog.js
@@ -70,7 +70,6 @@ class RulePickerDialog extends LocalizeDiscoverEntitlement(HypermediaStateMixin(
 	}
 
 	_onCancelClick() {
-		this._copiedConditions;
 		this.requestUpdate().then(() => {
 			const picker = this.shadowRoot.querySelector('d2l-discover-rule-picker');
 			picker.reload(this._copiedConditions);
@@ -84,13 +83,24 @@ class RulePickerDialog extends LocalizeDiscoverEntitlement(HypermediaStateMixin(
 
 	_onDoneClick() {
 		const picker = this.shadowRoot.querySelector('d2l-discover-rule-picker');
-		this._state.updateProperties({
-			conditions: {
-				observable: observableTypes.subEntities,
-				rel: rels.condition,
-				value: picker.conditions
-			}
-		});
+		if (this.creating) {
+			const event = new CustomEvent('d2l-discover-rule-created', {
+				bubbles: true,
+				detail: {
+					conditions: picker.conditions
+				}
+			});
+			this.dispatchEvent(event);
+			picker.reload([]);
+		} else {
+			this._state.updateProperties({
+				conditions: {
+					observable: observableTypes.subEntities,
+					rel: rels.condition,
+					value: picker.conditions
+				}
+			});
+		}
 		// action is commited differently because it's a JSON string
 		this.updateConditions.commit({
 			conditions: JSON.stringify(this.conditions.map(condition => {

--- a/features/discover/d2l-discover-rule-picker-dialog.js
+++ b/features/discover/d2l-discover-rule-picker-dialog.js
@@ -58,7 +58,7 @@ class RulePickerDialog extends LocalizeDiscoverEntitlement(HypermediaStateMixin(
 
 	updated(changedProperties) {
 		super.updated(changedProperties);
-		if (changedProperties.has('opened')) {
+		if (changedProperties.has('opened') && this.opened) {
 			this._copyConditions();
 		}
 	}
@@ -70,10 +70,10 @@ class RulePickerDialog extends LocalizeDiscoverEntitlement(HypermediaStateMixin(
 	}
 
 	_onCancelClick() {
-		this.conditions = this._copiedConditions;
+		this._copiedConditions;
 		this.requestUpdate().then(() => {
 			const picker = this.shadowRoot.querySelector('d2l-discover-rule-picker');
-			picker.reload(this.conditions);
+			picker.reload(this._copiedConditions);
 		});
 	}
 

--- a/features/discover/d2l-discover-rule-picker.js
+++ b/features/discover/d2l-discover-rule-picker.js
@@ -88,8 +88,9 @@ class RulePicker extends LocalizeDiscoverEntitlement(HypermediaStateMixin(RtlMix
 		}
 	}
 
-	reload(newConditions) {
+	async reload(newConditions) {
 		this.conditions = newConditions;
+		await this.updateComplete;
 
 		if (!this.conditions || this.conditions.length === 0) {
 			this._addDefaultCondition();

--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -71,6 +71,7 @@ class EntitlementRules extends LocalizeDiscoverEntitlement(SkeletonMixin(Hyperme
 				text="${this.localize('text-add-enrollment-rule')}"
 				icon="tier1:lock-locked"></d2l-button-subtle>
 			<d2l-discover-rule-picker-dialog
+				@d2l-discover-rule-created="${this._onRuleCreated}"
 				@d2l-dialog-close="${this._onDialogClose}"
 				href="${this._newRuleHref}"
 				token="${this.token}"
@@ -94,6 +95,10 @@ class EntitlementRules extends LocalizeDiscoverEntitlement(SkeletonMixin(Hyperme
 
 	_onDialogClose() {
 		this._dialogOpened = false;
+	}
+
+	_onRuleCreated() {
+		// todo: add the rule to the list of rules - we need engine support for this to create a pseudo-href
 	}
 
 }


### PR DESCRIPTION
## Context
[US123170](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F462626337568&fdp=true?fdp=true)

The rule picker dialog should remove changes from the dialog if cancel is pressed.
I could have sworn I had this working before. Anyway, it is fixed now.