### PR TITLE
doc: add engine link for observables to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Components that have not been made fully shareable can be found in the [features
 
 See [Creating new components](creating-new-components.md).
 
+For details on observable properties, see [observables](https://github.com/BrightspaceHypermediaComponents/foundation-engine/tree/master/state/observable) in the [Foundation Engine](https://github.com/BrightspaceHypermediaComponents/foundation-engine).
+
 ## Developing, Testing and Contributing
 
 After cloning the repo, run `npm install` to install dependencies.

--- a/creating-new-components.md
+++ b/creating-new-components.md
@@ -98,6 +98,8 @@ render() {
 }
 ```
 
+The following is a summary of the observable types and routing. For more details, see [observables](https://github.com/BrightspaceHypermediaComponents/foundation-engine/tree/master/state/observable) in the [Foundation Engine](https://github.com/BrightspaceHypermediaComponents/foundation-engine).
+
 ### Observable Types
 
 Types are based on Siren's hypermedia format.


### PR DESCRIPTION
### Context:
Currently it's hard to find the observables info for component creation. This is adding links to relevant documentation locations to make it easier to find when needed.