### PR TITLE
Making data files represent the APIs

### DIFF
--- a/components/activity/editor/demo/d2l-activity-editor.html
+++ b/components/activity/editor/demo/d2l-activity-editor.html
@@ -16,7 +16,7 @@
 		<d2l-demo-page page-title="Learning Path Editor">
 			<h2>New Learning Path</h2>
 			<d2l-demo-snippet>
-				<d2l-hc-activity-editor href="/demo/data/base/new-learning-path.json" token="cake"></d2l-hc-activity-editor>
+				<d2l-hc-activity-editor href="/demo/data/base/activity-usages/new-learning-path.json" token="cake"></d2l-hc-activity-editor>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>

--- a/demo/data/base/activity-usages/new-learning-path.json
+++ b/demo/data/base/activity-usages/new-learning-path.json
@@ -1,0 +1,31 @@
+{
+  "class":["activity-usage","learning-path","draft-published-entity","draft"],
+  "links":[
+    {
+      "rel":["https://activities.api.brightspace.com/rels/activity-usage","self"],
+      "href":"/demo/data/base/activity-usages/new-learning-path.json"
+    },
+    {
+      "rel":["https://activities.api.brightspace.com/rels/activity-collection"],
+      "href":"/demo/data/base/collection-empty.json"
+    },
+    {
+      "rel":["https://api.brightspace.com/rels/organization","https://api.brightspace.com/rels/specialization"],
+      "href":"/demo/data/base/organizations/new-learning-path.json"
+    }
+  ],
+  "actions": [
+    {
+      "href":"/activity-usage/update/draft",
+      "name":"update-draft",
+      "method":"PATCH",
+      "fields":[{"type":"checkbox","name":"draft","value":true}]
+    },
+    {
+      "href":"/activity-usage/associations",
+      "name":"query-associations",
+      "method":"GET",
+      "fields":[{"type":"text","name":"type"}]
+    }
+  ]
+}

--- a/demo/data/base/organizations/new-learning-path.json
+++ b/demo/data/base/organizations/new-learning-path.json
@@ -1,0 +1,55 @@
+{
+  "class":["named-entity","describable-entity","draft-published-entity","draft","creating","learning-path"],
+  "properties":{
+    "name":"Untitled Learning Path",
+    "code":"LP",
+    "startDate":null,
+    "endDate":null,
+    "isActive":false,
+    "description":""
+  },
+  "entities":[
+    {"class":["richtext","description"],"rel":["item"],"properties":{"text":"","html":null}},
+    {"class":["color"],"rel":["https://api.brightspace.com/rels/color"],"properties":{"hexString":"#2f5e00","description":""}},
+    {"class":["course-image"],"rel":["https://api.brightspace.com/rels/organization-image","nofollow"],"href":"https://s.brightspace.com/course-images/images/10054800-f859-4998-8f87-449742d41eb3"},
+    {"class":["relative-uri"],"rel":["item","https://api.brightspace.com/rels/organization-homepage"],"properties":{"path":"/d2l/le/learningpaths/123083/View"}}
+  ],
+  "links":[
+    {
+      "rel":["https://activities.api.brightspace.com/rels/activity-usage"],
+      "href":"/demo/data/base/activity-usages/new-learning-path.json"
+    },
+    {
+      "rel":["self"],
+      "href":"/demo/data/base/organizations/new-learning-path.json"
+    }
+  ],
+  "actions":[
+    {
+      "href":"/organizations/update/name",
+      "name":"update-name",
+      "method":"PATCH",
+      "fields":[{"class":["required"],"type":"text","name":"name","value":"Untitled Learning Path"}]
+      },
+    {
+      "href":"/organizations/update/description",
+      "name":"update-description","method":"PATCH",
+      "fields":[{"class":["required"],"type":"text","name":"description","value":""}]
+    },
+    {
+      "href":"/organizations/update/draft",
+      "name":"update-draft","method":"PATCH",
+      "fields":[{"type":"checkbox","name":"draft","value":true}]
+    },
+    {
+      "href":"/organizations/update/code",
+      "name":"update-code","method":"PATCH",
+      "fields":[{"type":"text","name":"code","value":"LP"}]
+    },
+    {
+      "href":"/organizations/de;ete",
+      "name":"delete",
+      "method":"DELETE"
+    }
+  ]
+}


### PR DESCRIPTION
```Context```
Started to mock API endpoint data for use with demo and testing. The data we were using to demo the activity editor was recently broke by removing the organization link. In my last attempt to fix it I replaced the link pointing the file to itself, which ended up causing the engine to loop until it failed.

This is my first attempt at creating a more realistic representation of the data we would receive from the APIs.

```Quality```
Demo no longer throws an error, but does not display due to a CSS issue that breaks the demo page.

```Questions```
Considering moving data to its own folder and making it shareable with tests



