### PR TITLE
US126109 dispatched update points event after collection refreshed

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -60,7 +60,10 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 		delayedResult.AddListener((/*result*/) => {
 			fetch(this._state, true).then(() => {
 				// refresh collection
-				fetch(Array.from(this._state._parents.keys())[0], true);
+				fetch(Array.from(this._state._parents.keys())[0], true).then(() => {
+					// refresh Quiz total points
+					this.dispatchEvent(new CustomEvent('update-total-quiz-points', {bubbles: true, composed: true}));
+				});
 			});
 		});
 	}

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -62,7 +62,7 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 				// refresh collection
 				fetch(Array.from(this._state._parents.keys())[0], true).then(() => {
 					// refresh Quiz total points
-					this.dispatchEvent(new CustomEvent('update-total-quiz-points', {bubbles: true, composed: true}));
+					this.dispatchEvent(new CustomEvent('d2l-question-updated', {bubbles: true, composed: true}));
 				});
 			});
 		});


### PR DESCRIPTION
Dispatching `update-total-quiz-points` event from `d2l-activity-collection-item-quiz`. This event is caught and handled in `d2l-activity-quiz-editor` in the `activities` repo.

**Related PRs:**
`siren-sdk`: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/301
`activities`: https://github.com/BrightspaceHypermediaComponents/activities/pull/1624

[US126109](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F512322551332&fdp=true?fdp=true): Refresh total points on edit

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F512322551332&fdp=true?fdp=true