### PR TITLE
US126257 refresh Section name on edit

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -4,7 +4,6 @@ import '../../../../list/custom/quiz/d2l-activity-list-item-section.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { fetch } from '@brightspace-hmc/foundation-engine/state/fetch.js';
-import { getComposedChildren } from '@brightspace-ui/core/helpers/dom.js';
 import { guard } from 'lit-html/directives/guard';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 
@@ -78,9 +77,7 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 	}
 
 	_refreshSection() {
-		const children = getComposedChildren(this);
-		if (!children) return;
-		const section = children[0].getElementsByTagName('d2l-activity-list-item-section')[0];
+		const section = this.renderRoot.children[0].querySelector('d2l-activity-list-item-section');
 		if (!section) return;
 		section.refetch();
 	}

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -4,6 +4,7 @@ import '../../../../list/custom/quiz/d2l-activity-list-item-section.js';
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { fetch } from '@brightspace-hmc/foundation-engine/state/fetch.js';
+import { getComposedChildren } from '@brightspace-ui/core/helpers/dom.js';
 import { guard } from 'lit-html/directives/guard';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 
@@ -61,8 +62,9 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 			fetch(this._state, true).then(() => {
 				// refresh collection
 				fetch(Array.from(this._state._parents.keys())[0], true).then(() => {
-					// refresh Quiz total points
+					// refresh Total Quiz Points, Section name
 					this.dispatchEvent(new CustomEvent('d2l-question-updated', {bubbles: true, composed: true}));
+					this._refreshSection();
 				});
 			});
 		});
@@ -73,6 +75,14 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 		const url = new D2L.LP.Web.Http.UrlLocation(
 			`/d2l/lms/question/edit/${this.key}`);
 		return open(url, 'SrcCallBack', 'result', [], false, '');
+	}
+
+	_refreshSection() {
+		const children = getComposedChildren(this);
+		if (!children) return;
+		const section = children[0].getElementsByTagName('d2l-activity-list-item-section')[0];
+		if (!section) return;
+		section.refetch();
 	}
 
 	_renderPrimaryAction(contentId) {

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -24,7 +24,10 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 				observable: observableTypes.property,
 				id: 'points'
 			},
-			_activityHref: { type: String, observable: observableTypes.link, rel: rels.activityUsage }
+			_activityHref: { type: String, observable: observableTypes.link, rel: rels.activityUsage },
+			_refreshCounter: {
+				type: Number,
+			}
 		};
 	}
 
@@ -35,14 +38,15 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 	constructor() {
 		super();
 		this.actionHref = '#';
+		this._refreshCounter = 0;
 	}
 
 	render() {
 		return this._renderListItem({
 			//${guard([this._activityHref, this.token], () => html`<d2l-activity-list-item-content href="${this._activityHref}" .token="${this.token}"></d2l-activity-list-item-content>`)}`
-			content: html`${guard([this._activityHref, this.token, this._points], () => html`
+			content: html`${guard([this._activityHref, this.token, this._points, this._refreshCounter], () => html`
 			<d2l-activity-list-item-quiz number="${this.number}" href="${this._activityHref}"
-				.token="${this.token}" points="${this._points}">
+				.token="${this.token}" points="${this._points}" refresh-counter="${this._refreshCounter}">
 
 			</d2l-activity-list-item-quiz>`)}`,
 			// actions: html`actions here`
@@ -63,7 +67,7 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 				fetch(Array.from(this._state._parents.keys())[0], true).then(() => {
 					// refresh Total Quiz Points, Section name
 					this.dispatchEvent(new CustomEvent('d2l-question-updated', {bubbles: true, composed: true}));
-					this._refreshSection();
+					++this._refreshCounter;
 				});
 			});
 		});
@@ -74,12 +78,6 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 		const url = new D2L.LP.Web.Http.UrlLocation(
 			`/d2l/lms/question/edit/${this.key}`);
 		return open(url, 'SrcCallBack', 'result', [], false, '');
-	}
-
-	_refreshSection() {
-		const section = this.renderRoot.children[0].querySelector('d2l-activity-list-item-section');
-		if (!section) return;
-		section.refetch();
 	}
 
 	_renderPrimaryAction(contentId) {

--- a/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
+++ b/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
@@ -48,6 +48,7 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 			},
 			refreshCounter: {
 				type: Number,
+				attribute: 'refresh-counter'
 			},
 			_refreshState: {
 				type: Object,

--- a/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
+++ b/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
@@ -46,6 +46,9 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 				rel: rels.item,
 				route: [route.collection]
 			},
+			refreshCounter: {
+				type: Number,
+			},
 			_refreshState: {
 				type: Object,
 				observable: observableTypes.refreshState,
@@ -111,8 +114,10 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 			</d2l-list>
 		`;
 	}
-	refetch() {
-		this._refreshState();
+	updated(changedProperties) {
+		if (changedProperties.has('refreshCounter') && this.refreshCounter > 0) {
+			this._refreshState();
+		}
 	}
 
 	get _loaded() {

--- a/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
+++ b/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
@@ -45,6 +45,11 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 				observable: observableTypes.subEntities,
 				rel: rels.item,
 				route: [route.collection]
+			},
+			_refreshState: {
+				type: Object,
+				observable: observableTypes.refreshState,
+				route: [route.specialization]
 			}
 		};
 	}
@@ -90,7 +95,6 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 		this.skeleton = true;
 		this.items = [];
 	}
-
 	render() {
 		// It is just a temporary solution to add nested list here. Waiting for the decision/discusson on how
 		// to do nested lists properly
@@ -106,6 +110,9 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 				`)}
 			</d2l-list>
 		`;
+	}
+	refetch() {
+		this._refreshState();
 	}
 
 	get _loaded() {


### PR DESCRIPTION
Refreshing the Section name after editing using the new `_refreshState` in `foundation-engine`.
Not to be merged until https://github.com/BrightspaceHypermediaComponents/foundation-engine/pull/91 is merged.

[US126257](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F514848992408%2Ftasks&fdp=true?fdp=true): Edit a section

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F514848992408%2Ftasks&fdp=true?fdp=true