### PR TITLE
feat: added work to do lang terms from activities repo

### DIFF
--- a/features/workToDo/lang/ar.js
+++ b/features/workToDo/lang/ar.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "اكتملت الأنشطة المستحقة أو التي تنتهي بعد أسبوعين! حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "ما من أنشطة متوفرة في الوقت الحالي!", // Displayed as header line in widget text when there are no activities
+  assignment: "الفرض",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "العودة إلى الصفحة الرئيسية", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "قائمة التحقق", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.", // 'Empty state' - When there are no activities in full page view
+  content: "المحتوى", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "المقرر التعليمي", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "المناقشة", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "عرض كل العمل", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "الانتقال إلى أداة الاكتشاف", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "تحميل المزيد", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "عرض المزيد من الأنشطة المعيّنة", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "العمل الذي يجب إنجازه", // Widget title
+  noActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "ليس لديك أي أنشطة غير مكتملة مستحقة أو تنتهي قريبًا. تحقق من الصفحة في وقت لاحق أو حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها. تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "ما من أنشطة هنا...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "الأنشطة التي تجاوزت تاريخ الاستحقاق", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "الاختبار", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "تاريخ البدء {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "الاستطلاع", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "عمل قادم", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "عرض كل العمل", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {أسبوع واحد} other {{count} من الأسابيع}} بدون أنشطة!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/ar.js
+++ b/features/workToDo/lang/ar.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "اكتملت الأنشطة المستحقة أو التي تنتهي بعد أسبوعين! حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "ما من أنشطة متوفرة في الوقت الحالي!", // Displayed as header line in widget text when there are no activities
-  assignment: "الفرض",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "العودة إلى الصفحة الرئيسية", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "قائمة التحقق", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.", // 'Empty state' - When there are no activities in full page view
-  content: "المحتوى", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "المقرر التعليمي", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "المناقشة", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "عرض كل العمل", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "الانتقال إلى أداة الاكتشاف", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "تحميل المزيد", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "عرض المزيد من الأنشطة المعيّنة", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "العمل الذي يجب إنجازه", // Widget title
-  noActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "ليس لديك أي أنشطة غير مكتملة مستحقة أو تنتهي قريبًا. تحقق من الصفحة في وقت لاحق أو حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها. تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "ما من أنشطة هنا...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "الأنشطة التي تجاوزت تاريخ الاستحقاق", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "الاختبار", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "تاريخ البدء {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "الاستطلاع", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "عمل قادم", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "عرض كل العمل", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {أسبوع واحد} other {{count} من الأسابيع}} بدون أنشطة!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'اكتملت الأنشطة المستحقة أو التي تنتهي بعد أسبوعين! حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'ما من أنشطة متوفرة في الوقت الحالي!', // Displayed as header line in widget text when there are no activities
+	assignment: 'الفرض',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'العودة إلى الصفحة الرئيسية', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'قائمة التحقق', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.', // 'Empty state' - When there are no activities in full page view
+	content: 'المحتوى', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'المقرر التعليمي', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'المناقشة', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'عرض كل العمل', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'الانتقال إلى أداة الاكتشاف', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'تحميل المزيد', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'عرض المزيد من الأنشطة المعيّنة', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'العمل الذي يجب إنجازه', // Widget title
+	noActivities: 'ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'ليس لديك أي أنشطة غير مكتملة مستحقة أو تنتهي قريبًا. تحقق من الصفحة في وقت لاحق أو حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها. تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'ما من أنشطة هنا...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'الأنشطة التي تجاوزت تاريخ الاستحقاق', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'الاختبار', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'تاريخ البدء {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'الاستطلاع', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'عمل قادم', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'عرض كل العمل', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {أسبوع واحد} other {{count} من الأسابيع}} بدون أنشطة!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/cy.js
+++ b/features/workToDo/lang/cy.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Mae gweithgareddau sy'n ddyledus neu'n dod i ben mewn pythefnos wedi’u cwblhau! Gwiriwch Gweld Pob Darn o Waith i weld beth sy'n dod yn nes ymlaen.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Dim Byd Am y Tro!", // Displayed as header line in widget text when there are no activities
+  assignment: "Aseiniad",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Yn ôl i’r Hafan", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Rhestr wirio", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty state' - When there are no activities in full page view
+  content: "Cynnwys", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cwrs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Trafodaeth", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Gweld pob darn o waith", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ewch i Darganfod", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Llwytho Mwy", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Dangos rhagor o weithgareddau penodedig", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Gwaith i’w Wneud", // Widget title
+  noActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn dyledus neu sy'n dod i ben yn fuan. Dewch yn ôl yn nes ymlaen neu Gweld Pob Darn o Waith i weld beth sy'n dod nesaf.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael. Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Does dim byd yma...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Yn hwyr", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Cwis", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Yn dechrau ar {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Arolwg", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Gwaith Ar Ddod", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Gweld Pob Darn o Waith", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "Mae {count, plural, =1 {1 wythnos} other{{count} wythnos}} wedi’u cwblhau!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/cy.js
+++ b/features/workToDo/lang/cy.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Mae gweithgareddau sy'n ddyledus neu'n dod i ben mewn pythefnos wedi’u cwblhau! Gwiriwch Gweld Pob Darn o Waith i weld beth sy'n dod yn nes ymlaen.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Dim Byd Am y Tro!", // Displayed as header line in widget text when there are no activities
-  assignment: "Aseiniad",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Yn ôl i’r Hafan", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Rhestr wirio", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty state' - When there are no activities in full page view
-  content: "Cynnwys", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Cwrs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Trafodaeth", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Gweld pob darn o waith", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Ewch i Darganfod", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Llwytho Mwy", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Dangos rhagor o weithgareddau penodedig", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Gwaith i’w Wneud", // Widget title
-  noActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn dyledus neu sy'n dod i ben yn fuan. Dewch yn ôl yn nes ymlaen neu Gweld Pob Darn o Waith i weld beth sy'n dod nesaf.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael. Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Does dim byd yma...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Yn hwyr", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Cwis", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Yn dechrau ar {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Arolwg", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Gwaith Ar Ddod", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Gweld Pob Darn o Waith", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "Mae {count, plural, =1 {1 wythnos} other{{count} wythnos}} wedi’u cwblhau!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: "Mae gweithgareddau sy'n ddyledus neu'n dod i ben mewn pythefnos wedi’u cwblhau! Gwiriwch Gweld Pob Darn o Waith i weld beth sy'n dod yn nes ymlaen.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Dim Byd Am y Tro!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Aseiniad',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Yn ôl i’r Hafan', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Rhestr wirio', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: "Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty state' - When there are no activities in full page view
+	content: 'Cynnwys', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Cwrs', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Trafodaeth', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Gweld pob darn o waith', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Ewch i Darganfod', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Llwytho Mwy', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Dangos rhagor o weithgareddau penodedig', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Gwaith i’w Wneud', // Widget title
+	noActivities: 'Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn dyledus neu sy'n dod i ben yn fuan. Dewch yn ôl yn nes ymlaen neu Gweld Pob Darn o Waith i weld beth sy'n dod nesaf.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael. Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Does dim byd yma...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Yn hwyr', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Cwis', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Yn dechrau ar {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Arolwg', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Gwaith Ar Ddod', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Gweld Pob Darn o Waith', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: 'Mae {count, plural, =1 {1 wythnos} other{{count} wythnos}} wedi’u cwblhau!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/da.js
+++ b/features/workToDo/lang/da.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Aktiviteter, der er forfaldne eller slutter om to uger, er fuldført! Kontrollér Se alle opgaver for at se, hvad der er på vej.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Alt er ryddet nu!", // Displayed as header line in widget text when there are no activities
-  assignment: "Opgave",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Tilbage til startsiden", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Tjekliste", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Kom tilbage senere for at se, om du har opgaver, der skal udføres.", // 'Empty state' - When there are no activities in full page view
-  content: "Indhold", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Kursus", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Se alle opgaver", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Gå til Registrer", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Indlæs flere", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Vis flere tildelte aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Opgaver, der skal udføres", // Widget title
-  noActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, der forfalder eller slutter snart. Kom tilbage senere eller Se alle opgaver for at se, hvad der er på vej.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige. Kom tilbage senere for at se, om du har opgaver, der skal udføres.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Der er intet her...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Forfalden", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Eksamination", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starter d. {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Undersøgelse", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Forestående opgaver", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Se alle opgaver", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 uge} other {{count} uger}} ryd!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Aktiviteter, der er forfaldne eller slutter om to uger, er fuldført! Kontrollér Se alle opgaver for at se, hvad der er på vej.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Alt er ryddet nu!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Opgave',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Tilbage til startsiden', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Tjekliste', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Kom tilbage senere for at se, om du har opgaver, der skal udføres.', // 'Empty state' - When there are no activities in full page view
+	content: 'Indhold', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Kursus', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Diskussion', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Se alle opgaver', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Gå til Registrer', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Indlæs flere', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Vis flere tildelte aktiviteter', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Opgaver, der skal udføres', // Widget title
+	noActivities: 'Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'Du har ingen ikke-gennemførte aktiviteter, der forfalder eller slutter snart. Kom tilbage senere eller Se alle opgaver for at se, hvad der er på vej.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige. Kom tilbage senere for at se, om du har opgaver, der skal udføres.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Der er intet her...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Forfalden', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Eksamination', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Starter d. {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Undersøgelse', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Forestående opgaver', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Se alle opgaver', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 uge} other {{count} uger}} ryd!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/da.js
+++ b/features/workToDo/lang/da.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Aktiviteter, der er forfaldne eller slutter om to uger, er fuldført! Kontrollér Se alle opgaver for at se, hvad der er på vej.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Alt er ryddet nu!", // Displayed as header line in widget text when there are no activities
+  assignment: "Opgave",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Tilbage til startsiden", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Tjekliste", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Kom tilbage senere for at se, om du har opgaver, der skal udføres.", // 'Empty state' - When there are no activities in full page view
+  content: "Indhold", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Kursus", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Se alle opgaver", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Gå til Registrer", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Indlæs flere", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Vis flere tildelte aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Opgaver, der skal udføres", // Widget title
+  noActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, der forfalder eller slutter snart. Kom tilbage senere eller Se alle opgaver for at se, hvad der er på vej.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige. Kom tilbage senere for at se, om du har opgaver, der skal udføres.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Der er intet her...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Forfalden", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Eksamination", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starter d. {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Undersøgelse", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Forestående opgaver", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Se alle opgaver", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 uge} other {{count} uger}} ryd!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/de.js
+++ b/features/workToDo/lang/de.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "In den nächsten zwei Wochen fällige oder endende Aktivitäten sind abgeschlossen! Aktivieren Sie „Alle Arbeiten anzeigen“, um zu sehen, was danach kommt.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Soweit alles klar!", // Displayed as header line in widget text when there are no activities
-  assignment: "Aufgabe",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Zurück zur Startseite", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checkliste", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.", // 'Empty state' - When there are no activities in full page view
-  content: "Inhalt", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Kurs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} – {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Alle Aufgaben anzeigen", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Zu Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Mehr laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Weitere zugewiesene Aktivitäten anzeigen", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Ausstehende Aufgaben", // Widget title
-  noActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Es sind keine unvollständigen Aktivitäten vorhanden, die in Kürze fällig sind oder enden. Kommen Sie später zurück oder sehen Sie sich alle Arbeiten an, um zu sehen, was als Nächstes kommt.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum. Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Hier gibt es nichts...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Überfällig", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Test", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Beginnt am {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Umfrage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Anstehende Aufgaben", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Alle Aufgaben anzeigen", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 Woche} other {{count} Wochen}} ohne Termine!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'In den nächsten zwei Wochen fällige oder endende Aktivitäten sind abgeschlossen! Aktivieren Sie „Alle Arbeiten anzeigen“, um zu sehen, was danach kommt.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Soweit alles klar!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Aufgabe',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Zurück zur Startseite', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Checkliste', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.', // 'Empty state' - When there are no activities in full page view
+	content: 'Inhalt', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Kurs', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} – {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Diskussion', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Alle Aufgaben anzeigen', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Zu Discover', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Mehr laden', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Weitere zugewiesene Aktivitäten anzeigen', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Ausstehende Aufgaben', // Widget title
+	noActivities: 'Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'Es sind keine unvollständigen Aktivitäten vorhanden, die in Kürze fällig sind oder enden. Kommen Sie später zurück oder sehen Sie sich alle Arbeiten an, um zu sehen, was als Nächstes kommt.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum. Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Hier gibt es nichts...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Überfällig', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Test', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Beginnt am {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Umfrage', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Anstehende Aufgaben', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Alle Aufgaben anzeigen', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 Woche} other {{count} Wochen}} ohne Termine!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/de.js
+++ b/features/workToDo/lang/de.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "In den nächsten zwei Wochen fällige oder endende Aktivitäten sind abgeschlossen! Aktivieren Sie „Alle Arbeiten anzeigen“, um zu sehen, was danach kommt.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Soweit alles klar!", // Displayed as header line in widget text when there are no activities
+  assignment: "Aufgabe",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Zurück zur Startseite", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checkliste", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.", // 'Empty state' - When there are no activities in full page view
+  content: "Inhalt", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Kurs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} – {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Alle Aufgaben anzeigen", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Zu Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Mehr laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Weitere zugewiesene Aktivitäten anzeigen", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Ausstehende Aufgaben", // Widget title
+  noActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Es sind keine unvollständigen Aktivitäten vorhanden, die in Kürze fällig sind oder enden. Kommen Sie später zurück oder sehen Sie sich alle Arbeiten an, um zu sehen, was als Nächstes kommt.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum. Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Hier gibt es nichts...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Überfällig", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Test", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Beginnt am {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Umfrage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Anstehende Aufgaben", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Alle Aufgaben anzeigen", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 Woche} other {{count} Wochen}} ohne Termine!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/en.js
+++ b/features/workToDo/lang/en.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/en.js
+++ b/features/workToDo/lang/en.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'All Clear For Now!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Assignment',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Back to Home', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Checklist', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Come back later to see if you have work to do.', // 'Empty state' - When there are no activities in full page view
+	content: 'Content', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Course', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Discussion', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'View all work', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Go To Discover', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Load More', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Display more assigned activities', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Work To Do', // Widget title
+	noActivities: 'You have no incomplete activities with due or end dates available.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Overdue', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Quiz', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Starts {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Survey', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Upcoming Work', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'View All Work', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 week} other {{count} weeks}} clear!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/es-es.js
+++ b/features/workToDo/lang/es-es.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Las actividades que vencen o terminan en dos semanas están completadas. Marque Ver todos los trabajos para saber lo que viene más tarde.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "¡Todo listo por ahora!", // Displayed as header line in widget text when there are no activities
+  assignment: "Tarea",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Volver a la página de inicio", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Lista de comprobación", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Vuelva más tarde para ver si tiene trabajo pendiente.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenido", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Debate", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Ver todos los trabajos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Vaya a Descubrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Cargar más", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Mostrar más actividades asignadas", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Trabajos pendientes", // Widget title
+  noActivities: "No tiene actividades incompletas con fecha de vencimiento o fecha final disponible.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "No tiene actividades incompletas pendientes o que finalicen pronto. Vuelva más tarde o vea todos los trabajos para saber lo que viene a continuación.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "No tiene actividades incompletas con fecha de vencimiento o fecha final disponible. Vuelva más tarde para ver si tiene trabajo pendiente.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "No hay nada aquí...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Vencidas", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Cuestionario", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Se inicia el {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Encuesta", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Próximos trabajos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Ver todos los trabajos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {¡1 semana libre!} other {¡{count} semanas libres!}}" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/es-es.js
+++ b/features/workToDo/lang/es-es.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Las actividades que vencen o terminan en dos semanas están completadas. Marque Ver todos los trabajos para saber lo que viene más tarde.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "¡Todo listo por ahora!", // Displayed as header line in widget text when there are no activities
-  assignment: "Tarea",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Volver a la página de inicio", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Lista de comprobación", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Vuelva más tarde para ver si tiene trabajo pendiente.", // 'Empty state' - When there are no activities in full page view
-  content: "Contenido", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Debate", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Ver todos los trabajos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Vaya a Descubrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Cargar más", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Mostrar más actividades asignadas", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Trabajos pendientes", // Widget title
-  noActivities: "No tiene actividades incompletas con fecha de vencimiento o fecha final disponible.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "No tiene actividades incompletas pendientes o que finalicen pronto. Vuelva más tarde o vea todos los trabajos para saber lo que viene a continuación.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "No tiene actividades incompletas con fecha de vencimiento o fecha final disponible. Vuelva más tarde para ver si tiene trabajo pendiente.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "No hay nada aquí...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Vencidas", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Cuestionario", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Se inicia el {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Encuesta", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Próximos trabajos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Ver todos los trabajos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {¡1 semana libre!} other {¡{count} semanas libres!}}" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Las actividades que vencen o terminan en dos semanas están completadas. Marque Ver todos los trabajos para saber lo que viene más tarde.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: '¡Todo listo por ahora!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Tarea',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Volver a la página de inicio', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Lista de comprobación', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Vuelva más tarde para ver si tiene trabajo pendiente.', // 'Empty state' - When there are no activities in full page view
+	content: 'Contenido', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Curso', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Debate', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Ver todos los trabajos', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Vaya a Descubrir', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Cargar más', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Mostrar más actividades asignadas', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Trabajos pendientes', // Widget title
+	noActivities: 'No tiene actividades incompletas con fecha de vencimiento o fecha final disponible.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'No tiene actividades incompletas pendientes o que finalicen pronto. Vuelva más tarde o vea todos los trabajos para saber lo que viene a continuación.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'No tiene actividades incompletas con fecha de vencimiento o fecha final disponible. Vuelva más tarde para ver si tiene trabajo pendiente.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'No hay nada aquí...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Vencidas', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Cuestionario', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Se inicia el {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Encuesta', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Próximos trabajos', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Ver todos los trabajos', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {¡1 semana libre!} other {¡{count} semanas libres!}}' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/es.js
+++ b/features/workToDo/lang/es.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Se completaron las actividades pendientes o que finalizan en dos semanas. Revise la sección Ver todos los trabajos para saber lo que viene después.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "¡Todo claro hasta ahora!", // Displayed as header line in widget text when there are no activities
+  assignment: "Asignación",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Volver a Inicio", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Lista de verificación", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenido", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Debate", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Ver todos los trabajos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ir a Descubrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Cargar más", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Mostrar más actividades asignadas", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Tareas pendientes", // Widget title
+  noActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "No tiene actividades sin completar pendientes o que finalicen pronto. Vuelva más tarde o revise la sección Ver todos los trabajos para ver próximas tareas.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles. Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "No hay nada aquí…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Vencida", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Cuestionario", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Inicia el {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Encuesta", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Próximos trabajos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Ver todos los trabajos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 semana} other {{count} semanas}} despejada(s)." // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/es.js
+++ b/features/workToDo/lang/es.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Se completaron las actividades pendientes o que finalizan en dos semanas. Revise la sección Ver todos los trabajos para saber lo que viene después.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "¡Todo claro hasta ahora!", // Displayed as header line in widget text when there are no activities
-  assignment: "Asignación",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Volver a Inicio", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Lista de verificación", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty state' - When there are no activities in full page view
-  content: "Contenido", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Debate", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Ver todos los trabajos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Ir a Descubrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Cargar más", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Mostrar más actividades asignadas", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Tareas pendientes", // Widget title
-  noActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "No tiene actividades sin completar pendientes o que finalicen pronto. Vuelva más tarde o revise la sección Ver todos los trabajos para ver próximas tareas.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles. Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "No hay nada aquí…", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Vencida", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Cuestionario", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Inicia el {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Encuesta", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Próximos trabajos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Ver todos los trabajos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 semana} other {{count} semanas}} despejada(s)." // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Se completaron las actividades pendientes o que finalizan en dos semanas. Revise la sección Ver todos los trabajos para saber lo que viene después.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: '¡Todo claro hasta ahora!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Asignación',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Volver a Inicio', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Lista de verificación', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Vuelva más tarde para ver si tiene trabajo que hacer.', // 'Empty state' - When there are no activities in full page view
+	content: 'Contenido', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Curso', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startDay} {startMonth} - {endDay} {endMonth}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Debate', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Ver todos los trabajos', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Ir a Descubrir', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Cargar más', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Mostrar más actividades asignadas', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Tareas pendientes', // Widget title
+	noActivities: 'No tiene actividades sin completar pendientes o con fechas finales disponibles.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'No tiene actividades sin completar pendientes o que finalicen pronto. Vuelva más tarde o revise la sección Ver todos los trabajos para ver próximas tareas.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'No tiene actividades sin completar pendientes o con fechas finales disponibles. Vuelva más tarde para ver si tiene trabajo que hacer.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'No hay nada aquí…', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Vencida', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Cuestionario', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Inicia el {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Encuesta', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Próximos trabajos', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Ver todos los trabajos', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 semana} other {{count} semanas}} despejada(s).' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/fr-fr.js
+++ b/features/workToDo/lang/fr-fr.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Les activités à remettre ou se terminant dans deux semaines sont terminées ! Cochez Afficher tout le travail pour voir les activités à venir.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Il n’y a rien pour le moment !", // Displayed as header line in widget text when there are no activities
+  assignment: "Devoir",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Retourner à la page d’accueil", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Liste de contrôle", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Revenez plus tard pour vérifier si vous avez du travail à faire.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Afficher tout le travail", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Accéder à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Charger plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Travail à faire", // Widget title
+  noActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Vous n’avez aucune activité incomplète ou se terminant bientôt. Revenez plus tard ou cliquez sur Afficher tout le travail pour voir les activités à venir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles. Revenez plus tard pour vérifier si vous avez du travail à faire.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Il n’y a rien ici...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Travail à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Afficher tout le travail", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 semaine terminée} other {{count} semaines terminées}} terminée(s) !" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/fr-fr.js
+++ b/features/workToDo/lang/fr-fr.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Les activités à remettre ou se terminant dans deux semaines sont terminées ! Cochez Afficher tout le travail pour voir les activités à venir.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Il n’y a rien pour le moment !", // Displayed as header line in widget text when there are no activities
-  assignment: "Devoir",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Retourner à la page d’accueil", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Liste de contrôle", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Revenez plus tard pour vérifier si vous avez du travail à faire.", // 'Empty state' - When there are no activities in full page view
-  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Afficher tout le travail", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Accéder à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Charger plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Travail à faire", // Widget title
-  noActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Vous n’avez aucune activité incomplète ou se terminant bientôt. Revenez plus tard ou cliquez sur Afficher tout le travail pour voir les activités à venir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles. Revenez plus tard pour vérifier si vous avez du travail à faire.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Il n’y a rien ici...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Travail à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Afficher tout le travail", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 semaine terminée} other {{count} semaines terminées}} terminée(s) !" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Les activités à remettre ou se terminant dans deux semaines sont terminées ! Cochez Afficher tout le travail pour voir les activités à venir.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Il n’y a rien pour le moment !', // Displayed as header line in widget text when there are no activities
+	assignment: 'Devoir',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Retourner à la page d’accueil', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Liste de contrôle', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Revenez plus tard pour vérifier si vous avez du travail à faire.', // 'Empty state' - When there are no activities in full page view
+	content: 'Contenu', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Cours', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startDay} {startMonth} - {endDay} {endMonth}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Discussion', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Afficher tout le travail', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Accéder à Découvrir', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Charger plus', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Afficher plus d’activités attribuées', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Travail à faire', // Widget title
+	noActivities: 'Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'Vous n’avez aucune activité incomplète ou se terminant bientôt. Revenez plus tard ou cliquez sur Afficher tout le travail pour voir les activités à venir.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles. Revenez plus tard pour vérifier si vous avez du travail à faire.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Il n’y a rien ici...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'En retard', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Questionnaire', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Débute le {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Sondage', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Travail à venir', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Afficher tout le travail', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 semaine terminée} other {{count} semaines terminées}} terminée(s) !' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/fr-on.js
+++ b/features/workToDo/lang/fr-on.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Rien de plus pour l’instant!", // Displayed as header line in widget text when there are no activities
-  assignment: "Travail",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Retour à l’accueil", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Liste des rappels", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Revenez plus tard pour voir si vous avez du travail.", // 'Empty state' - When there are no activities in full page view
-  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Afficher tous les travaux", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Allez à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "En voir plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Travaux à faire", // Widget title
-  noActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Vous n’avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Il n’y a rien ici…", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Travaux à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Afficher tous les travaux", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "Rien de plus pour {count, plural, =1 {1 week} other {{count} weeks}}!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Rien de plus pour l’instant!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Travail',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Retour à l’accueil', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Liste des rappels', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Revenez plus tard pour voir si vous avez du travail.', // 'Empty state' - When there are no activities in full page view
+	content: 'Contenu', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Cours', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Discussion', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Afficher tous les travaux', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Allez à Découvrir', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'En voir plus', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Afficher plus d’activités attribuées', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Travaux à faire', // Widget title
+	noActivities: 'Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'Vous n’avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Il n’y a rien ici…', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'En retard', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Questionnaire', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Débute le {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Sondage', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Travaux à venir', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Afficher tous les travaux', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: 'Rien de plus pour {count, plural, =1 {1 week} other {{count} weeks}}!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/fr-on.js
+++ b/features/workToDo/lang/fr-on.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Rien de plus pour l’instant!", // Displayed as header line in widget text when there are no activities
+  assignment: "Travail",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Retour à l’accueil", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Liste des rappels", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Revenez plus tard pour voir si vous avez du travail.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Afficher tous les travaux", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Allez à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "En voir plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Travaux à faire", // Widget title
+  noActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Vous n’avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Il n’y a rien ici…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Travaux à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Afficher tous les travaux", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "Rien de plus pour {count, plural, =1 {1 week} other {{count} weeks}}!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/fr.js
+++ b/features/workToDo/lang/fr.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Rien de plus pour l'instant!", // Displayed as header line in widget text when there are no activities
-  assignment: "Travail",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Retour à l'accueil", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Liste des rappels", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Revenez plus tard pour voir si vous avez du travail.", // 'Empty state' - When there are no activities in full page view
-  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Afficher tous les travaux", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Allez à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "En voir plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Afficher plus d'activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Travaux à faire", // Widget title
-  noActivities: "Vous n'avez pas d'activités non terminées avec les dates d'échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Vous n'avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Vous n'avez pas d'activités non terminées avec les dates d'échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Il n'y a rien ici…", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Travaux à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Afficher tous les travaux", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {Rien de plus pour 1 semaine!} other {Rien de plus pour {count} semaines!}}" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: "Rien de plus pour l'instant!", // Displayed as header line in widget text when there are no activities
+	assignment: 'Travail',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: "Retour à l'accueil", // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Liste des rappels', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Revenez plus tard pour voir si vous avez du travail.', // 'Empty state' - When there are no activities in full page view
+	content: 'Contenu', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Cours', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Discussion', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Afficher tous les travaux', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Allez à Découvrir', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'En voir plus', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: "Afficher plus d'activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Travaux à faire', // Widget title
+	noActivities: "Vous n'avez pas d'activités non terminées avec les dates d'échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "Vous n'avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "Vous n'avez pas d'activités non terminées avec les dates d'échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: "Il n'y a rien ici…", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'En retard', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Questionnaire', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Débute le {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Sondage', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Travaux à venir', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Afficher tous les travaux', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {Rien de plus pour 1 semaine!} other {Rien de plus pour {count} semaines!}}' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/fr.js
+++ b/features/workToDo/lang/fr.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Rien de plus pour l'instant!", // Displayed as header line in widget text when there are no activities
+  assignment: "Travail",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Retour à l'accueil", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Liste des rappels", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Revenez plus tard pour voir si vous avez du travail.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Afficher tous les travaux", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Allez à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "En voir plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Afficher plus d'activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Travaux à faire", // Widget title
+  noActivities: "Vous n'avez pas d'activités non terminées avec les dates d'échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Vous n'avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Vous n'avez pas d'activités non terminées avec les dates d'échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Il n'y a rien ici…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Travaux à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Afficher tous les travaux", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {Rien de plus pour 1 semaine!} other {Rien de plus pour {count} semaines!}}" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/ja.js
+++ b/features/workToDo/lang/ja.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "2 週間以内に期限を迎えるまたは終了するアクティビティは完了しました。［すべての学習の表示］をチェックして、次のアクティビティを確認してください", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "今はすべて完了！", // Displayed as header line in widget text when there are no activities
-  assignment: "課題",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "ホームに戻る", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "チェックリスト", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "後でまた、アクティビティがあるか確認してください。", // 'Empty state' - When there are no activities in full page view
-  content: "コンテンツ", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "コース", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth}/{startDay} ～ {endMonth}/{endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "ディスカッション", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "すべての学習の表示", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "［Discover］に移動", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "さらに読み込む", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "割り当てられたその他のアクティビティを表示します", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "取り組むこと", // Widget title
-  noActivities: "期限または終了日が設定された未完了のアクティビティはありません。", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "期限または終了日が近い未完了のアクティビティはありません。後でまた確認するか、［すべての学習の表示］をクリックして次のアクティビティを確認してください。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "期限または終了日が設定された未完了のアクティビティはありません。後でまた、アクティビティがあるか確認してください。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "何もありません ...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "期限切れ", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "クイズ", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "開始日 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "調査", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "今後の学習", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "すべての学習の表示", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "この先 {count, plural, =1 {1 週間} other {{count} 週間}}何もありません。" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: '2 週間以内に期限を迎えるまたは終了するアクティビティは完了しました。［すべての学習の表示］をチェックして、次のアクティビティを確認してください', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: '今はすべて完了！', // Displayed as header line in widget text when there are no activities
+	assignment: '課題',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'ホームに戻る', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'チェックリスト', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: '後でまた、アクティビティがあるか確認してください。', // 'Empty state' - When there are no activities in full page view
+	content: 'コンテンツ', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'コース', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth}/{startDay} ～ {endMonth}/{endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'ディスカッション', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'すべての学習の表示', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: '［Discover］に移動', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'さらに読み込む', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: '割り当てられたその他のアクティビティを表示します', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: '取り組むこと', // Widget title
+	noActivities: '期限または終了日が設定された未完了のアクティビティはありません。', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: '期限または終了日が近い未完了のアクティビティはありません。後でまた確認するか、［すべての学習の表示］をクリックして次のアクティビティを確認してください。',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: '期限または終了日が設定された未完了のアクティビティはありません。後でまた、アクティビティがあるか確認してください。', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: '何もありません ...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: '期限切れ', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'クイズ', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: '開始日 {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: '調査', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: '今後の学習', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'すべての学習の表示', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: 'この先 {count, plural, =1 {1 週間} other {{count} 週間}}何もありません。' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/ja.js
+++ b/features/workToDo/lang/ja.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "2 週間以内に期限を迎えるまたは終了するアクティビティは完了しました。［すべての学習の表示］をチェックして、次のアクティビティを確認してください", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "今はすべて完了！", // Displayed as header line in widget text when there are no activities
+  assignment: "課題",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "ホームに戻る", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "チェックリスト", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "後でまた、アクティビティがあるか確認してください。", // 'Empty state' - When there are no activities in full page view
+  content: "コンテンツ", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "コース", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth}/{startDay} ～ {endMonth}/{endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "ディスカッション", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "すべての学習の表示", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "［Discover］に移動", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "さらに読み込む", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "割り当てられたその他のアクティビティを表示します", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "取り組むこと", // Widget title
+  noActivities: "期限または終了日が設定された未完了のアクティビティはありません。", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "期限または終了日が近い未完了のアクティビティはありません。後でまた確認するか、［すべての学習の表示］をクリックして次のアクティビティを確認してください。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "期限または終了日が設定された未完了のアクティビティはありません。後でまた、アクティビティがあるか確認してください。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "何もありません ...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "期限切れ", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "クイズ", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "開始日 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "調査", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "今後の学習", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "すべての学習の表示", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "この先 {count, plural, =1 {1 週間} other {{count} 週間}}何もありません。" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/ko.js
+++ b/features/workToDo/lang/ko.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "2주 내에 완료되거나 끝나는 활동이 완료되었습니다! 모든 작업 보기 를 선택하여 나중에 어떤 작업을 할 수 있는지 확인합니다.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "지금 모두 지우기!", // Displayed as header line in widget text when there are no activities
-  assignment: "과제",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "홈으로 돌아가기", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "체크리스트", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "나중에 돌아와 해야 할 일이 있는지 확인합니다.", // 'Empty state' - When there are no activities in full page view
-  content: "콘텐츠", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "강의", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay}-{endMonth}{endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "토론", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "모든 작업 보기", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "검색으로 이동합니다.", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "더 많이 로드", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "할당된 활동을 더 많이 표시합니다", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "할 일", // Widget title
-  noActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "기한이 만료되거나 곧 종료되는 활동이 없습니다. 나중에 다시 돌아오거나 모든 작업 보기 를 통해 다음 내용을 확인할 수 있습니다.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다. 나중에 돌아와 해야 할 일이 있는지 확인합니다.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "여기에 아무것도 없습니다...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "기한 경과", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "퀴즈", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "{startDate}에 시작", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "설문조사", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "예정된 작업", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "모든 작업 보기", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1주} other {{count}주}} 완료!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: '2주 내에 완료되거나 끝나는 활동이 완료되었습니다! 모든 작업 보기 를 선택하여 나중에 어떤 작업을 할 수 있는지 확인합니다.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: '지금 모두 지우기!', // Displayed as header line in widget text when there are no activities
+	assignment: '과제',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: '홈으로 돌아가기', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: '체크리스트', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: '나중에 돌아와 해야 할 일이 있는지 확인합니다.', // 'Empty state' - When there are no activities in full page view
+	content: '콘텐츠', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: '강의', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay}-{endMonth}{endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: '토론', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: '모든 작업 보기', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: '검색으로 이동합니다.', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: '더 많이 로드', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: '할당된 활동을 더 많이 표시합니다', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: '할 일', // Widget title
+	noActivities: '기한 또는 종료일이 있는 미완료 활동이 없습니다.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: '기한이 만료되거나 곧 종료되는 활동이 없습니다. 나중에 다시 돌아오거나 모든 작업 보기 를 통해 다음 내용을 확인할 수 있습니다.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: '기한 또는 종료일이 있는 미완료 활동이 없습니다. 나중에 돌아와 해야 할 일이 있는지 확인합니다.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: '여기에 아무것도 없습니다...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: '기한 경과', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: '퀴즈', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: '{startDate}에 시작', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: '설문조사', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: '예정된 작업', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: '모든 작업 보기', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1주} other {{count}주}} 완료!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/ko.js
+++ b/features/workToDo/lang/ko.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "2주 내에 완료되거나 끝나는 활동이 완료되었습니다! 모든 작업 보기 를 선택하여 나중에 어떤 작업을 할 수 있는지 확인합니다.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "지금 모두 지우기!", // Displayed as header line in widget text when there are no activities
+  assignment: "과제",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "홈으로 돌아가기", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "체크리스트", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "나중에 돌아와 해야 할 일이 있는지 확인합니다.", // 'Empty state' - When there are no activities in full page view
+  content: "콘텐츠", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "강의", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay}-{endMonth}{endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "토론", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "모든 작업 보기", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "검색으로 이동합니다.", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "더 많이 로드", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "할당된 활동을 더 많이 표시합니다", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "할 일", // Widget title
+  noActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "기한이 만료되거나 곧 종료되는 활동이 없습니다. 나중에 다시 돌아오거나 모든 작업 보기 를 통해 다음 내용을 확인할 수 있습니다.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다. 나중에 돌아와 해야 할 일이 있는지 확인합니다.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "여기에 아무것도 없습니다...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "기한 경과", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "퀴즈", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "{startDate}에 시작", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "설문조사", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "예정된 작업", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "모든 작업 보기", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1주} other {{count}주}} 완료!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/nl.js
+++ b/features/workToDo/lang/nl.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activiteiten die de komende twee weken moeten worden uitgevoerd of beëindigd, zijn voltooid! Bekijk Al het werk weergeven om te zien wat er op komst is.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Alles is nu klaar!", // Displayed as header line in widget text when there are no activities
-  assignment: "Opdracht",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Terug naar startpagina", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Kom later terug om te zien of er werk is.", // 'Empty state' - When there are no activities in full page view
-  content: "Inhoud", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Cursus", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussie", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Al het werk weergeven", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Ga naar Ontdekken", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Meer laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Meer toegewezen activiteiten weergeven", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
-  noActivities: "U hebt geen onvoltooide activiteiten met vervaldatums of einddatums beschikbaar.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "U hebt geen onvoltooide activiteiten die binnenkort vervallen of eindigen. Kom later terug of bekijk Al het werk weergeven om te zien wat er op komst is.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "U hebt geen onvoltooide activiteiten met vervaldatums of einddatums beschikbaar. Kom later terug om te zien of er werk is.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Er is hier niets...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Achterstallig", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Test", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Begint op {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Enquête", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Komend werk", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Al het werk weergeven", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week klaar!} other {{count} weken klaar!}}" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Activiteiten die de komende twee weken moeten worden uitgevoerd of beëindigd, zijn voltooid! Bekijk Al het werk weergeven om te zien wat er op komst is.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Alles is nu klaar!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Opdracht',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Terug naar startpagina', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Checklist', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Kom later terug om te zien of er werk is.', // 'Empty state' - When there are no activities in full page view
+	content: 'Inhoud', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Cursus', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Discussie', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Al het werk weergeven', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Ga naar Ontdekken', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Meer laden', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Meer toegewezen activiteiten weergeven', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Work To Do', // Widget title
+	noActivities: 'U hebt geen onvoltooide activiteiten met vervaldatums of einddatums beschikbaar.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'U hebt geen onvoltooide activiteiten die binnenkort vervallen of eindigen. Kom later terug of bekijk Al het werk weergeven om te zien wat er op komst is.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'U hebt geen onvoltooide activiteiten met vervaldatums of einddatums beschikbaar. Kom later terug om te zien of er werk is.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Er is hier niets...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Achterstallig', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Test', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Begint op {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Enquête', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Komend werk', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Al het werk weergeven', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 week klaar!} other {{count} weken klaar!}}' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/nl.js
+++ b/features/workToDo/lang/nl.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Activiteiten die de komende twee weken moeten worden uitgevoerd of beëindigd, zijn voltooid! Bekijk Al het werk weergeven om te zien wat er op komst is.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Alles is nu klaar!", // Displayed as header line in widget text when there are no activities
+  assignment: "Opdracht",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Terug naar startpagina", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Kom later terug om te zien of er werk is.", // 'Empty state' - When there are no activities in full page view
+  content: "Inhoud", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cursus", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussie", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Al het werk weergeven", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ga naar Ontdekken", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Meer laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Meer toegewezen activiteiten weergeven", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Work To Do", // Widget title
+  noActivities: "U hebt geen onvoltooide activiteiten met vervaldatums of einddatums beschikbaar.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "U hebt geen onvoltooide activiteiten die binnenkort vervallen of eindigen. Kom later terug of bekijk Al het werk weergeven om te zien wat er op komst is.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "U hebt geen onvoltooide activiteiten met vervaldatums of einddatums beschikbaar. Kom later terug om te zien of er werk is.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Er is hier niets...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Achterstallig", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Test", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Begint op {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Enquête", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Komend werk", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Al het werk weergeven", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week klaar!} other {{count} weken klaar!}}" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/pt.js
+++ b/features/workToDo/lang/pt.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "As atividades que vencem ou encerram em duas semanas estão concluídas! Marque Exibir todos os trabalhos para ver o que está por vir.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Tudo certo por enquanto!", // Displayed as header line in widget text when there are no activities
-  assignment: "Atividade",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Voltar ao Início", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Lista de verificação", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Volte mais tarde para verificar se você tem trabalho pendente.", // 'Empty state' - When there are no activities in full page view
-  content: "Conteúdo", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startDay} de {startMonth} – {endDay} de {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussão", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Exibir todos os trabalhos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Ir para o Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Carregar mais", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Exibir mais atividades atribuídas", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Trabalho pendente", // Widget title
-  noActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Você não tem atividades incompletas que vencem ou encerram em breve. Volte mais tarde ou selecione Exibir todos os trabalhos para ver o que está por vir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis. Volte mais tarde para verificar se você tem trabalho pendente.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Não há nada aqui…", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Atraso", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Questionário", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Início: {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Pesquisa", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Próximos trabalhos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Exibir todos os trabalhos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 semana} other {{count} semanas}} sem trabalhos a fazer!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'As atividades que vencem ou encerram em duas semanas estão concluídas! Marque Exibir todos os trabalhos para ver o que está por vir.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Tudo certo por enquanto!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Atividade',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Voltar ao Início', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Lista de verificação', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Volte mais tarde para verificar se você tem trabalho pendente.', // 'Empty state' - When there are no activities in full page view
+	content: 'Conteúdo', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Curso', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startDay} de {startMonth} – {endDay} de {endMonth}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Discussão', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Exibir todos os trabalhos', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Ir para o Discover', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Carregar mais', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Exibir mais atividades atribuídas', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Trabalho pendente', // Widget title
+	noActivities: 'Você não tem atividades incompletas com prazos ou datas finais disponíveis.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'Você não tem atividades incompletas que vencem ou encerram em breve. Volte mais tarde ou selecione Exibir todos os trabalhos para ver o que está por vir.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'Você não tem atividades incompletas com prazos ou datas finais disponíveis. Volte mais tarde para verificar se você tem trabalho pendente.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Não há nada aqui…', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Atraso', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Questionário', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Início: {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Pesquisa', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Próximos trabalhos', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Exibir todos os trabalhos', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 semana} other {{count} semanas}} sem trabalhos a fazer!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/pt.js
+++ b/features/workToDo/lang/pt.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "As atividades que vencem ou encerram em duas semanas estão concluídas! Marque Exibir todos os trabalhos para ver o que está por vir.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Tudo certo por enquanto!", // Displayed as header line in widget text when there are no activities
+  assignment: "Atividade",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Voltar ao Início", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Lista de verificação", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Volte mais tarde para verificar se você tem trabalho pendente.", // 'Empty state' - When there are no activities in full page view
+  content: "Conteúdo", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startDay} de {startMonth} – {endDay} de {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussão", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Exibir todos os trabalhos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ir para o Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Carregar mais", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Exibir mais atividades atribuídas", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Trabalho pendente", // Widget title
+  noActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Você não tem atividades incompletas que vencem ou encerram em breve. Volte mais tarde ou selecione Exibir todos os trabalhos para ver o que está por vir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis. Volte mais tarde para verificar se você tem trabalho pendente.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Não há nada aqui…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Atraso", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Questionário", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Início: {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Pesquisa", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Próximos trabalhos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Exibir todos os trabalhos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 semana} other {{count} semanas}} sem trabalhos a fazer!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/sv.js
+++ b/features/workToDo/lang/sv.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Aktiviteter som förfaller eller slutar inom två veckor är slutförda! Markera Visa alla jobb om du vill se vad som kommer längre fram.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Allt klart nu!", // Displayed as header line in widget text when there are no activities
+  assignment: "Uppgift",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Tillbaka till hemsida", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklista", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Kom tillbaka senare för att se om du har arbete att göra.", // 'Empty state' - When there are no activities in full page view
+  content: "Innehåll", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Kurs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay}–{endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Visa alla jobb", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Gå till Upptäck", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Läs in fler", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Visa fler tilldelade aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Arbete att göra", // Widget title
+  noActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Du har inga ofullständiga aktiviteter som förfaller eller slutar snart. Kom tillbaka senare eller Visa alla jobb för att se vad som kommer härnäst.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum. Kom tillbaka senare för att se om du har arbete att göra.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Det finns inget här …", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Försenad", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Förhör", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Börjar {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Enkät", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Kommande jobb", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Se allt", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 vecka} other {{count} veckor}} rensat!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/sv.js
+++ b/features/workToDo/lang/sv.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Aktiviteter som förfaller eller slutar inom två veckor är slutförda! Markera Visa alla jobb om du vill se vad som kommer längre fram.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Allt klart nu!", // Displayed as header line in widget text when there are no activities
-  assignment: "Uppgift",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Tillbaka till hemsida", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklista", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Kom tillbaka senare för att se om du har arbete att göra.", // 'Empty state' - When there are no activities in full page view
-  content: "Innehåll", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Kurs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay}–{endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Visa alla jobb", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Gå till Upptäck", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Läs in fler", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Visa fler tilldelade aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Arbete att göra", // Widget title
-  noActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Du har inga ofullständiga aktiviteter som förfaller eller slutar snart. Kom tillbaka senare eller Visa alla jobb för att se vad som kommer härnäst.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum. Kom tillbaka senare för att se om du har arbete att göra.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Det finns inget här …", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Försenad", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Förhör", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Börjar {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Enkät", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Kommande jobb", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Se allt", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 vecka} other {{count} veckor}} rensat!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Aktiviteter som förfaller eller slutar inom två veckor är slutförda! Markera Visa alla jobb om du vill se vad som kommer längre fram.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Allt klart nu!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Uppgift',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Tillbaka till hemsida', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Checklista', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Kom tillbaka senare för att se om du har arbete att göra.', // 'Empty state' - When there are no activities in full page view
+	content: 'Innehåll', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Kurs', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay}–{endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Diskussion', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Visa alla jobb', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: 'Gå till Upptäck', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Läs in fler', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Visa fler tilldelade aktiviteter', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Arbete att göra', // Widget title
+	noActivities: 'Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'Du har inga ofullständiga aktiviteter som förfaller eller slutar snart. Kom tillbaka senare eller Visa alla jobb för att se vad som kommer härnäst.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum. Kom tillbaka senare för att se om du har arbete att göra.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Det finns inget här …', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Försenad', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Förhör', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Börjar {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Enkät', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Kommande jobb', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Se allt', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 vecka} other {{count} veckor}} rensat!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/tr.js
+++ b/features/workToDo/lang/tr.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Teslim tarihi veya sona erme tarihi iki hafta içinde olan etkinlikler tamamlandı! Daha sonraki etkinlikleri görmek için Tüm İşleri Görüntüle seçeneğini işaretleyin.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "Şimdilik Her Şey Tamamlandı!", // Displayed as header line in widget text when there are no activities
-  assignment: "Ödev",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Ana Sayfaya Geri Dön", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Kontrol Listesi", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.", // 'Empty state' - When there are no activities in full page view
-  content: "İçerik", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Ders", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Tartışma", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "Tüm çalışmaları görüntüle", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Keşfet'e Git", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Daha Fazla Yükle", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Daha fazla atanmış etkinlik görüntüle", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Yapılacak İşler", // Widget title
-  noActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "Teslim veya sona erme tarihi yaklaşmakta olan tamamlanmamış etkinliğiniz yok. Daha sonraki etkinlikleri görmek için daha sonra tekrar ziyaret edin veya Tüm İşleri Görüntüleyin.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok. Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "Hiçbir şey yok...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Süresi Dolmuş", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Sınav", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Başlama Tarihi: {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Anket", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Yaklaşan İş", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "Tüm İşleri Görüntüle", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 hafta} other {{count} hafta}} tamamlandı!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: 'Teslim tarihi veya sona erme tarihi iki hafta içinde olan etkinlikler tamamlandı! Daha sonraki etkinlikleri görmek için Tüm İşleri Görüntüle seçeneğini işaretleyin.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: 'Şimdilik Her Şey Tamamlandı!', // Displayed as header line in widget text when there are no activities
+	assignment: 'Ödev',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: 'Ana Sayfaya Geri Dön', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: 'Kontrol Listesi', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: 'Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.', // 'Empty state' - When there are no activities in full page view
+	content: 'İçerik', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: 'Ders', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startDay} {startMonth} - {endDay} {endMonth}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: 'Tartışma', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: 'Tüm çalışmaları görüntüle', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: "Keşfet'e Git", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: 'Daha Fazla Yükle', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: 'Daha fazla atanmış etkinlik görüntüle', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: 'Yapılacak İşler', // Widget title
+	noActivities: 'Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok.', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: 'Teslim veya sona erme tarihi yaklaşmakta olan tamamlanmamış etkinliğiniz yok. Daha sonraki etkinlikleri görmek için daha sonra tekrar ziyaret edin veya Tüm İşleri Görüntüleyin.',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: 'Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok. Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: 'Hiçbir şey yok...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: 'Süresi Dolmuş', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: 'Sınav', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: 'Başlama Tarihi: {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: 'Anket', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: 'Yaklaşan İş', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: 'Tüm İşleri Görüntüle', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 hafta} other {{count} hafta}} tamamlandı!' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/tr.js
+++ b/features/workToDo/lang/tr.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "Teslim tarihi veya sona erme tarihi iki hafta içinde olan etkinlikler tamamlandı! Daha sonraki etkinlikleri görmek için Tüm İşleri Görüntüle seçeneğini işaretleyin.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Şimdilik Her Şey Tamamlandı!", // Displayed as header line in widget text when there are no activities
+  assignment: "Ödev",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Ana Sayfaya Geri Dön", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Kontrol Listesi", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.", // 'Empty state' - When there are no activities in full page view
+  content: "İçerik", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Ders", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Tartışma", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Tüm çalışmaları görüntüle", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Keşfet'e Git", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Daha Fazla Yükle", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Daha fazla atanmış etkinlik görüntüle", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Yapılacak İşler", // Widget title
+  noActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Teslim veya sona erme tarihi yaklaşmakta olan tamamlanmamış etkinliğiniz yok. Daha sonraki etkinlikleri görmek için daha sonra tekrar ziyaret edin veya Tüm İşleri Görüntüleyin.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok. Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Hiçbir şey yok...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Süresi Dolmuş", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Sınav", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Başlama Tarihi: {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Anket", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Yaklaşan İş", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Tüm İşleri Görüntüle", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 hafta} other {{count} hafta}} tamamlandı!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/zh-cn.js
+++ b/features/workToDo/lang/zh-cn.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "两周内到期或结束的活动已完成！选中“查看所有工作”以查看即将发布的工作。", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "现在已经全部清楚！", // Displayed as header line in widget text when there are no activities
+  assignment: "作业",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "返回主页", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "清单", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "稍后回来查看您是否有工作要完成。", // 'Empty state' - When there are no activities in full page view
+  content: "内容", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "课程", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "讨论", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "查看所有作业", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "转至“发现”", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "加载更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "显示更多已分配的活动", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "待办事项", // Widget title
+  noActivities: "您没有具有到期或结束日期的未完成活动。", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "您没有到期或即将结束的未完成活动。稍后回来或查看所有工作以查看即将发布的工作。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "您没有具有到期或结束日期的未完成活动。稍后回来查看您是否有工作要完成。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "没有任何工作...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "过期", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "测验", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "开始日期 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "调查", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "即将分配的作业", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "查看所有作业", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 周} other {{count} 周}} 清楚！" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/zh-cn.js
+++ b/features/workToDo/lang/zh-cn.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "两周内到期或结束的活动已完成！选中“查看所有工作”以查看即将发布的工作。", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "现在已经全部清楚！", // Displayed as header line in widget text when there are no activities
-  assignment: "作业",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "返回主页", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "清单", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "稍后回来查看您是否有工作要完成。", // 'Empty state' - When there are no activities in full page view
-  content: "内容", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "课程", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "讨论", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "查看所有作业", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "转至“发现”", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "加载更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "显示更多已分配的活动", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "待办事项", // Widget title
-  noActivities: "您没有具有到期或结束日期的未完成活动。", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "您没有到期或即将结束的未完成活动。稍后回来或查看所有工作以查看即将发布的工作。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "您没有具有到期或结束日期的未完成活动。稍后回来查看您是否有工作要完成。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "没有任何工作...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "过期", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "测验", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "开始日期 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "调查", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "即将分配的作业", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "查看所有作业", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 周} other {{count} 周}} 清楚！" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: '两周内到期或结束的活动已完成！选中“查看所有工作”以查看即将发布的工作。', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: '现在已经全部清楚！', // Displayed as header line in widget text when there are no activities
+	assignment: '作业',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: '返回主页', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: '清单', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: '稍后回来查看您是否有工作要完成。', // 'Empty state' - When there are no activities in full page view
+	content: '内容', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: '课程', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: '讨论', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: '查看所有作业', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: '转至“发现”', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: '加载更多', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: '显示更多已分配的活动', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: '待办事项', // Widget title
+	noActivities: '您没有具有到期或结束日期的未完成活动。', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: '您没有到期或即将结束的未完成活动。稍后回来或查看所有工作以查看即将发布的工作。',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: '您没有具有到期或结束日期的未完成活动。稍后回来查看您是否有工作要完成。', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: '没有任何工作...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: '过期', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: '测验', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: '开始日期 {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: '调查', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: '即将分配的作业', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: '查看所有作业', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 周} other {{count} 周}} 清楚！' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/features/workToDo/lang/zh-tw.js
+++ b/features/workToDo/lang/zh-tw.js
@@ -1,0 +1,28 @@
+export const val = {
+  activitiesAvailable: "兩週內截止的活動都已完成！請查看「檢視所有作業」，來瞭解接下來的活動。", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "目前已全數清空！", // Displayed as header line in widget text when there are no activities
+  assignment: "作業",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "返回首頁", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "檢查表", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "請稍後再回來看看是否有工作要進行。", // 'Empty state' - When there are no activities in full page view
+  content: "內容", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "課程", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "討論", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "檢視所有作業", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "前往「探索」", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "載入更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "顯示更多已指派的活動", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "待做作業", // Widget title
+  noActivities: "您沒有具有截止日期或結束日期的未完成活動。", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "您沒有即將截止的未完成活動。請稍後再回來，或透過「檢視所有工作」來瞭解接下來的活動。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "您沒有具有截止日期或結束日期的未完成活動。請稍後再回來看看是否有工作要進行。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "這裡沒有任何內容...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "逾期", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "測驗", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "開始於 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "問卷調查", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "近期作業", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "檢視所有作業", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 週} other {{count} 週}}內均已清空！" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/features/workToDo/lang/zh-tw.js
+++ b/features/workToDo/lang/zh-tw.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "兩週內截止的活動都已完成！請查看「檢視所有作業」，來瞭解接下來的活動。", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "目前已全數清空！", // Displayed as header line in widget text when there are no activities
-  assignment: "作業",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "返回首頁", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "檢查表", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "請稍後再回來看看是否有工作要進行。", // 'Empty state' - When there are no activities in full page view
-  content: "內容", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "課程", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "討論", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "檢視所有作業", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "前往「探索」", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "載入更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "顯示更多已指派的活動", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "待做作業", // Widget title
-  noActivities: "您沒有具有截止日期或結束日期的未完成活動。", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "您沒有即將截止的未完成活動。請稍後再回來，或透過「檢視所有工作」來瞭解接下來的活動。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "您沒有具有截止日期或結束日期的未完成活動。請稍後再回來看看是否有工作要進行。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "這裡沒有任何內容...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "逾期", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "測驗", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "開始於 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "問卷調查", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "近期作業", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "檢視所有作業", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 週} other {{count} 週}}內均已清空！" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-}
+	activitiesAvailable: '兩週內截止的活動都已完成！請查看「檢視所有作業」，來瞭解接下來的活動。', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear: '目前已全數清空！', // Displayed as header line in widget text when there are no activities
+	assignment: '作業',  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L: '返回首頁', // Displayed in the immersive navbar to escape out of fullscreen view
+	checklist: '檢查表', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities: '請稍後再回來看看是否有工作要進行。', // 'Empty state' - When there are no activities in full page view
+	content: '內容', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	course: '課程', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader: '{startMonth} {startDay} - {endMonth} {endDay}', // Indicates that the below list of activities are due/end within the listed date range
+	discussion: '討論', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: '檢視所有作業', // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover: '前往「探索」', // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore: '載入更多', // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription: '顯示更多已指派的活動', // Additional description text to accompany the load more button for additional clarity for the user
+	workToDo: '待做作業', // Widget title
+	noActivities: '您沒有具有截止日期或結束日期的未完成活動。', // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: '您沒有即將截止的未完成活動。請稍後再回來，或透過「檢視所有工作」來瞭解接下來的活動。',  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: '您沒有具有截止日期或結束日期的未完成活動。請稍後再回來看看是否有工作要進行。', // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere: '這裡沒有任何內容...', // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue: '逾期', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: '測驗', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate: '開始於 {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	survey: '問卷調查', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming: '近期作業', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork: '檢視所有作業', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear: '{count, plural, =1 {1 週} other {{count} 週}}內均已清空！' // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/foundation-components.serge.json
+++ b/foundation-components.serge.json
@@ -260,5 +260,28 @@
       "zh-cn zh",
       "zh-tw zh-tw"
     ]
+  }, {
+    "name": "WorkToDo",
+    "source_dir": "components/features/workToDo/lang",
+    "source_match": "en\\.js$",
+    "output_file_path": "components/features/workToDo/lang/%LANG%.js",
+    "parser_plugin": {
+      "plugin": "parse_js"
+    },
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ]
   }
 ]


### PR DESCRIPTION
### Context:
https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F514448373588
Working on making empty widget panels. Figured we should take the old lang terms to make our lives easier.