### PR TITLE
fix: Removing the discover rules label

### DIFF
--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -34,7 +34,6 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 
 	static get styles() {
 		return [ super.styles, bodySmallStyles, css`
-			h4.d2l-body-small,
 			h5.d2l-body-small {
 				color: var(--d2l-color-ferrite);
 				margin: 0.7rem 0;
@@ -58,7 +57,6 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 
 	render() {
 		return html`
-			<h4 class="d2l-body-small d2l-skeletize"><strong>${this.localize('text-title')}</strong></h4>
 			<d2l-labs-checkbox-drawer
 				?checked="${this.isSelfEnrollable || (this.rules && this.rules.length)}"
 				label="${this.localize('label-checkbox')}"
@@ -104,7 +102,7 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 	}
 
 	_onRuleCreated() {
-		// todo: add the rule to the list of rules - we need engine support for this to create a pseudo-href
+		// todo: we should actually send the action here
 	}
 
 }


### PR DESCRIPTION
## Context
[US120165](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F424331214124&fdp=true?fdp=true)

Removing the label for Discover rules because it's less complicated than hiding the existing one in the LMS. This should also ensure more consistent spacing, plus makes this component more reusable.

## Quality
- Demo page