### PR TITLE
fix: US126257 skeletonize section on QED close

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -62,11 +62,12 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 
 		// Save or Cancel button Handler
 		delayedResult.AddListener((/*result*/) => {
+			// Trigger Section child to refresh name
 			++this._refreshCounter;
 			fetch(this._state, true).then(() => {
 				// refresh collection
 				fetch(Array.from(this._state._parents.keys())[0], true).then(() => {
-					// refresh Total Quiz Points, Section name
+					// refresh Total Quiz Points
 					this.dispatchEvent(new CustomEvent('d2l-question-updated', {bubbles: true, composed: true}));
 				});
 			});

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -62,12 +62,12 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 
 		// Save or Cancel button Handler
 		delayedResult.AddListener((/*result*/) => {
+			++this._refreshCounter;
 			fetch(this._state, true).then(() => {
 				// refresh collection
 				fetch(Array.from(this._state._parents.keys())[0], true).then(() => {
 					// refresh Total Quiz Points, Section name
 					this.dispatchEvent(new CustomEvent('d2l-question-updated', {bubbles: true, composed: true}));
-					++this._refreshCounter;
 				});
 			});
 		});

--- a/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
+++ b/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
@@ -117,6 +117,7 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 	}
 	updated(changedProperties) {
 		if (changedProperties.has('refreshCounter') && this.refreshCounter > 0) {
+			this.skeleton = true;
 			this._refreshState();
 		}
 	}

--- a/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
+++ b/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
@@ -117,7 +117,6 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 	}
 	updated(changedProperties) {
 		if (changedProperties.has('refreshCounter') && this.refreshCounter > 0) {
-			this.skeleton = true;
 			this._refreshState();
 		}
 	}


### PR DESCRIPTION
~~I was having a bit of a hard time verifying this in the UI with my networks speeds but I think~~ this change should force the Section name to skeletonize after QED closes so we don't have the issue of the old section name persisting for a few seconds before it gets updated.

[US126257](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F514848992408&fdp=true?fdp=true): [ui] Edit a section