### PR TITLE
fix: Adjusting margin for Discover subtle buttons

### DIFF
--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -41,6 +41,9 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 			h5.d2l-body-small + p {
 				margin-top: 0;
 			}
+			d2l-button-subtle {
+				margin-left: -0.65rem;
+			}
 		` ];
 	}
 
@@ -58,6 +61,7 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 	render() {
 		return html`
 			<d2l-labs-checkbox-drawer
+				@d2l-checkbox-drawer-checked-change="${this._onCheckboxChange}"
 				?checked="${this.isSelfEnrollable || (this.rules && this.rules.length)}"
 				label="${this.localize('label-checkbox')}"
 				description="${this.localize('text-checkbox-description')}"
@@ -97,12 +101,20 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 		this._dialogOpened = true;
 	}
 
+	_onCheckboxChange(e) {
+		if (e.detail.checked) {
+			// todo: commit action to make discoverable
+		} else {
+			// todo: commit action to make not discoverable
+		}
+	}
+
 	_onDialogClose() {
 		this._dialogOpened = false;
 	}
 
 	_onRuleCreated() {
-		// todo: we should actually send the action here
+		// todo: commit action to make not discoverable AND create entitlement
 	}
 
 }


### PR DESCRIPTION
## Context
Jeff wants things to line up! Also adjusted the wording on the todos and made some room for things that will need to happen in the near future.

### UX Result
<img width="431" alt="Screen Shot 2021-04-08 at 2 32 48 PM" src="https://user-images.githubusercontent.com/2412740/114085711-b59a7800-987f-11eb-8258-cda820427185.png">

## Quality
Checked for pixel perfect in Photoshop