### PR TITLE
fix quiz collection item checkbox at root level

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -85,18 +85,6 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 			`/d2l/lms/question/edit/${this.key}`);
 		return open(url, 'SrcCallBack', 'result', [], false, '');
 	}
-	_renderCheckbox() {
-		const disabled = this.disabled || this.skeleton;
-		return this.selectable ? html`
-			<input
-				id="${this._checkboxId}"
-				class="d2l-input-checkbox d2l-skeletize"
-				@change="${this._onCheckboxChange}"
-				type="checkbox"
-				.checked="${this.selected}"
-				?disabled="${disabled}">
-			` : html ``;
-	}
 	_renderPrimaryAction(contentId) {
 		return html `<a aria-labelledby="${contentId}" href="#" @click="${this._handleLinkClick}"></a>`;
 	}

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -40,6 +40,7 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 		super();
 		this.actionHref = '#';
 		this._refreshCounter = 0;
+		this.selectable = true;
 	}
 
 	render() {
@@ -78,7 +79,19 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 			`/d2l/lms/question/edit/${this.key}`);
 		return open(url, 'SrcCallBack', 'result', [], false, '');
 	}
-
+	_renderCheckbox() {
+		const disabled = this.disabled || this.skeleton;
+		return this.selectable ? html`
+			<input
+				id="${this._checkboxId}"
+				class="d2l-input-checkbox d2l-skeletize"
+				@change="${this._onCheckboxChange}"
+				style="margin-top: 0.7rem"
+				type="checkbox"
+				.checked="${this.selected}"
+				?disabled="${disabled}">
+			` : html ``;
+	}
 	_renderPrimaryAction(contentId) {
 		return html `<a aria-labelledby="${contentId}" href="#" @click="${this._handleLinkClick}"></a>`;
 	}

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -33,7 +33,13 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 	}
 
 	static get styles() {
-		return [ super.styles, css `` ];
+		return [
+			super.styles,
+			css `
+				input[type="checkbox"].d2l-input-checkbox {
+							margin-top: 0.7rem;
+				}
+			` ];
 	}
 
 	constructor() {
@@ -86,7 +92,6 @@ const componentClass = class extends HypermediaStateMixin(ListItemLinkMixin(LitE
 				id="${this._checkboxId}"
 				class="d2l-input-checkbox d2l-skeletize"
 				@change="${this._onCheckboxChange}"
-				style="margin-top: 0.7rem"
 				type="checkbox"
 				.checked="${this.selected}"
 				?disabled="${disabled}">

--- a/components/activity/list/custom/quiz/d2l-activity-list-item-question.js
+++ b/components/activity/list/custom/quiz/d2l-activity-list-item-question.js
@@ -108,14 +108,13 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 	render() {
 		return html`
 			<div class="question-item d2l-skeletize">
-				<div class="checkbox"><d2l-input-checkbox></d2l-input-checkbox></div>
 				<div class="d2l-body-standard question-number d2l-skeletize">${this.number}</div>
 				<div class="question d2l-skeletize">
 					<span class="d2l-body-compact d2l-skeletize">${this.name || this.questionText}</span>
 					<div class="d2l-body-small question-type d2l-skeletize">${this.typeText}</div>
 				</div>
 				<div class="points d2l-body-compact d2l-skeletize">${this.localize('points', { count: this.points })}</div>
-			</div>			
+			</div>
 		`;
 	}
 

--- a/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
+++ b/components/activity/list/custom/quiz/d2l-activity-list-item-section.js
@@ -88,7 +88,8 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 					margin: 0;
 				}
 				.section-nested-items {
-					margin-left: 2rem
+					margin-left: 2rem;
+					margin-top: 1rem;
 				}
 			`];
 	}
@@ -103,12 +104,11 @@ const componentClass = class extends SkeletonMixin(HypermediaStateMixin(Localize
 		// to do nested lists properly
 		return html`
 			<div class="section-item d2l-skeletize">
-				<div class="checkbox"><d2l-input-checkbox></d2l-input-checkbox></div>
 				<div class="section d2l-skeletize">
 					<span class="d2l-heading-2 d2l-skeletize">${this.name}</span>
 					<div class="d2l-body-small section-type d2l-skeletize">${this.typeText}</div>
 				</div>
-			</div>			
+			</div>
 			<d2l-list separators="none" class="section-nested-items" @d2l-list-item-position-change="${this._moveItems}">
 				${repeat(this.items, item => item.href, (item, idx) => html`
 					<d2l-activity-collection-item-quiz number="${idx + 1}" href="${item.href}" .token="${this.token}" key="${item.properties.id}"></d2l-activity-collection-item-quiz>


### PR DESCRIPTION
Fix for:  "When using FACE Quiz, user cannot check the checkmark next to an existing question, section, (assume question pool too). Instead it goes into edit.  Seems like the click target is the whole row?"

Note this bug still happens for items nested within sections but the proper way to render nested lists are still a WIP.

https://trello.com/c/GKSEmBoY