### PR TITLE
fix: move start date to the attribute list

### DIFF
--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -121,7 +121,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 
 		const startDate = (!this.actionHref && this._dates.start)
 			? html`
-				<d2l-status-indicator slot="supporting-info" state="none" text="Starts ${formatDate(this._dates.start, {format: 'shortMonthDay'})}"></d2l-status-indicator>
+				<div><d2l-status-indicator slot="supporting-info" state="none" text="Starts ${formatDate(this._dates.start, {format: 'shortMonthDay'})}"></d2l-status-indicator></div>
 			`
 			: nothing;
 
@@ -131,9 +131,8 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 				<d2l-list-item-content>
 					<d2l-activity-name class="d2l-w2d-list-item-name" href="${this.href}" .token="${this.token}"></d2l-activity-name>
 					<d2l-w2d-attribute-list slot="secondary">
-						${this._renderAttributeListCollapsed()}
+						${startDate} ${this._renderAttributeListCollapsed()}
 					</d2l-w2d-attribute-list>
-					${startDate}
 					${ !this.collapsed ? html`<d2l-activity-description slot="supporting-info" href="${this.href}" .token="${this.token}"></d2l-activity-description>` : nothing}
 				</d2l-list-item-content>
 			`)}`

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -124,7 +124,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 
 		const startDate = (!this.actionHref && this._dates.start)
 			? html`
-				<div><d2l-status-indicator slot="supporting-info" state="none" text="Starts ${formatDate(this._dates.start, {format: 'shortMonthDay'})}"></d2l-status-indicator></div>
+				<d2l-status-indicator ${ !this.collapsed ? html`slot="supporting-info"` : nothing } state="none" text="Starts ${formatDate(this._dates.start, {format: 'shortMonthDay'})}"></d2l-status-indicator>
 			`
 			: nothing;
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -131,9 +131,11 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 				<d2l-list-item-content>
 					<d2l-activity-name class="d2l-w2d-list-item-name" href="${this.href}" .token="${this.token}"></d2l-activity-name>
 					<d2l-w2d-attribute-list slot="secondary">
-						${startDate} ${this._renderAttributeListCollapsed()}
+						${ !this.collapsed ? startDate : nothing }
+						${this._renderAttributeListCollapsed()}
 					</d2l-w2d-attribute-list>
-					${ !this.collapsed ? html`<d2l-activity-description slot="supporting-info" href="${this.href}" .token="${this.token}"></d2l-activity-description>` : nothing}
+
+					${ !this.collapsed ? html`<d2l-activity-description slot="supporting-info" href="${this.href}" .token="${this.token}"></d2l-activity-description>` : startDate}
 				</d2l-list-item-content>
 			`)}`
 		});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/BrightspaceHypermediaComponents/foundation-components.git"
   },
-  "version": "0.33.0",
+  "version": "0.33.1",
   "scripts": {
     "lint": "npm run lint:eslint && npm run lint:lit",
     "lint:eslint": "eslint . --ext .js,.html",


### PR DESCRIPTION
### Context:
[US127302](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F600483964584&fdp=true?fdp=true)
The start date in full screen is currently displayed in line with the description. We want it to be inline with the type of activity and course.