### PR TITLE
feat: work to do message displays different empty messages

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -143,7 +143,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		this._categories = [];
 		this._overdue = [];
 		this.collapsed = false;
-		this._pagingTotalResults = 0;
+		this._totalActivities = 0;
 		this.requiredPropertyForState('currentTime');
 		this.requiredPropertyForState('groupByDays');
 		this.requiredPropertyForState('overdueGroupByDays');

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -65,7 +65,21 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 					collapsed: 'collapsed'
 				}],
 				method: (categories) => Object.values(categories)
-			}
+			},
+			_totalActivities: {
+				type: Number,
+				name: 'totalActivities',
+				observable: observableTypes.property,
+				route: [{
+					observable: observableTypes.custom,
+					observableObject: W2dSummonAction,
+					name: 'filter-work-to-do',
+					startDate: 'startDate',
+					endDate: 'endDate',
+					pageSize: '_pageSize',
+					page: '_pageUpcoming'
+				}]
+			},
 		};
 	}
 
@@ -129,6 +143,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		this._categories = [];
 		this._overdue = [];
 		this.collapsed = false;
+		this._pagingTotalResults = 0;
 		this.requiredPropertyForState('currentTime');
 		this.requiredPropertyForState('groupByDays');
 		this.requiredPropertyForState('overdueGroupByDays');
@@ -145,10 +160,11 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 				<d2l-w2d-list skeleton ?collapsed="${this.collapsed}"></d2l-w2d-list>
 			`;
 		}
+
 		if (this._overdue.length === 0 && this._categories.length === 0) {
 			return html`
 				<d2l-w2d-no-activities
-					?activities="${this.collapsed}"
+					?activities="${this._totalActivities !== 0}"
 					?collapsed="${this.collapsed}"
 					?complete="${!this.collapsed}"
 					data-full-page-path=${this.dataFullPagePath}></d2l-w2d-no-activities>

--- a/features/workToDo/d2l-w2d-no-activities.js
+++ b/features/workToDo/d2l-w2d-no-activities.js
@@ -136,13 +136,10 @@ class w2dNoActivities extends LocalizeDynamicMixin(LitElement) {
 	}
 
 	_renderEmptyViewText() {
-
 		let emptyViewTextLabel = 'noActivitiesNoFutureActivities';
-		if (this.activities && this.complete && this.collapse) {
-			emptyViewTextLabel = 'activitiesAvailable';
-		} else if (this.activities && this.collapse) {
+		if (this.activities && !this.collapse) {
 			emptyViewTextLabel = 'noActivitiesFutureActivities';
-		} else if (!this.collapse) {
+		} else if (this.collapse) {
 			emptyViewTextLabel = 'noActivities';
 		}
 
@@ -150,8 +147,6 @@ class w2dNoActivities extends LocalizeDynamicMixin(LitElement) {
 			<div class="d2l-body-standard d2l-empty-body-text-container">
 				${this.localize(emptyViewTextLabel)}
 			</div>
-			${!this.collapse ? html`<div class="d2l-body-standard d2l-empty-body-text-container">
-			${this.localize('comeBackNoFutureActivities')}</div>` : html``}
 			`;
 	}
 


### PR DESCRIPTION
### Context:
[DE43228](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F600191816024&fdp=true?fdp=true)
Based on the state of future events, we want to display different messages to the learner. This updates the widget to display appropriate messages.

### Quality:
Tested locally.