### PR TITLE
fix: Discovery bff integration - add rules field

### DIFF
--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -126,7 +126,9 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 			rule.entities.forEach(condition => ruleObj[condition.properties.type] = condition.properties.values);
 			return ruleObj;
 		});
-		this._createEntitlement.commit(message);
+		this._createEntitlement.commit({
+			rules: message
+		});
 	}
 
 }

--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -121,11 +121,11 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 
 	_onRulesChanged() {
 		if (!this._hasAction('_createEntitlement')) return;
-		const message = JSON.stringify(this._rules.map(rule => {
+		const message = this._rules.map(rule => {
 			const ruleObj = {};
 			rule.entities.forEach(condition => ruleObj[condition.properties.type] = condition.properties.values);
 			return ruleObj;
-		}));
+		});
 		this._createEntitlement.commit(message);
 	}
 

--- a/features/discover/test/d2l-discover-rules.test.js
+++ b/features/discover/test/d2l-discover-rules.test.js
@@ -104,9 +104,11 @@ describe('d2l-discover-rules', () => {
 			// click done
 			dialog.shadowRoot.querySelector('d2l-button[primary]').click();
 			await dialog.updateComplete;
-			const expectedCommit = [
-				{ entree: ['spaghetti'], dessert: ['cake', 'pie'] }
-			];
+			const expectedCommit = {
+				rules: [
+					{ entree: ['spaghetti'], dessert: ['cake', 'pie'] }
+				]
+			};
 
 			expect(spy.calledOnce, 'commit was not called').to.be.true;
 			expect(spy.calledWith(expectedCommit), `commit was not called with: ${expectedCommit}`).to.be.true;

--- a/features/discover/test/d2l-discover-rules.test.js
+++ b/features/discover/test/d2l-discover-rules.test.js
@@ -104,9 +104,9 @@ describe('d2l-discover-rules', () => {
 			// click done
 			dialog.shadowRoot.querySelector('d2l-button[primary]').click();
 			await dialog.updateComplete;
-			const expectedCommit = JSON.stringify([
+			const expectedCommit = [
 				{ entree: ['spaghetti'], dessert: ['cake', 'pie'] }
-			]);
+			];
 
 			expect(spy.calledOnce, 'commit was not called').to.be.true;
 			expect(spy.calledWith(expectedCommit), `commit was not called with: ${expectedCommit}`).to.be.true;


### PR DESCRIPTION
## Context
[US126747](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F519521658884&fdp=true?fdp=true)
- Uses the `rules` field added in the BFF: https://github.com/Brightspace/discovery-bff/pull/119
- Removes the JSON encoding from here because this is done already in the engine.

This should help make the request more consistent with other hypermedia APIs. This approach was chosen over altering the `foundation-engine` to support unnamed arrays.

## Quality
- Existing unit tests