### PR TITLE
fix: W2D. add context to number in header to screen reader

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -216,7 +216,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		return html`
 			<div class="d2l-w2d-flex">
 				<h2 class="d2l-heading-2">${heading}</h2>
-				<div class="d2l-w2d-count d2l-w2d-heading-2-count" aria-label="${activityCount}">${count}</div>
+				<div class="d2l-w2d-count d2l-w2d-heading-2-count" aria-hidden=true>${count}</div>
 			</div>
 		`;
 	}
@@ -227,7 +227,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		return html`
 			<div class="d2l-w2d-flex">
 				<h3 class="d2l-w2d-heading-3 d2l-heading-3">${heading}</h3>
-				<div class="d2l-w2d-count d2l-w2d-heading-3-count" aria-label="${activityCount}">${count}</div>
+				<div class="d2l-w2d-count d2l-w2d-heading-3-count" aria-hidden=true>${count}</div>
 			</div>
 		`;
 	}

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -212,7 +212,6 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderHeader2(heading, count) {
 		if (this.collapsed) return;
-		const activityCount = this.localize('totalActivities', 'count', count);
 		return html`
 			<div class="d2l-w2d-flex">
 				<h2 class="d2l-heading-2">${heading}</h2>
@@ -223,7 +222,6 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderHeader3(heading, count) {
 		if (!this.collapsed) return html`<div class="d2l-w2d-flex"><h3 class="d2l-w2d-heading-3">${heading}</h3></div>`;
-		const activityCount = this.localize('totalActivities', 'count', count);
 		return html`
 			<div class="d2l-w2d-flex">
 				<h3 class="d2l-w2d-heading-3 d2l-heading-3">${heading}</h3>

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -212,20 +212,22 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderHeader2(heading, count) {
 		if (this.collapsed) return;
+		const activityCount = this.localize('totalActivities', 'count', count);
 		return html`
 			<div class="d2l-w2d-flex">
 				<h2 class="d2l-heading-2">${heading}</h2>
-				<div class="d2l-w2d-count d2l-w2d-heading-2-count">${count}</div>
+				<div class="d2l-w2d-count d2l-w2d-heading-2-count" aria-label="${activityCount}">${count}</div>
 			</div>
 		`;
 	}
 
 	_renderHeader3(heading, count) {
 		if (!this.collapsed) return html`<div class="d2l-w2d-flex"><h3 class="d2l-w2d-heading-3">${heading}</h3></div>`;
+		const activityCount = this.localize('totalActivities', 'count', count);
 		return html`
 			<div class="d2l-w2d-flex">
 				<h3 class="d2l-w2d-heading-3 d2l-heading-3">${heading}</h3>
-				<div class="d2l-w2d-count d2l-w2d-heading-3-count">${count}</div>
+				<div class="d2l-w2d-count d2l-w2d-heading-3-count" aria-label="${activityCount}">${count}</div>
 			</div>
 		`;
 	}

--- a/features/workToDo/lang/en-us.js
+++ b/features/workToDo/lang/en-us.js
@@ -24,6 +24,7 @@ export default {
 	quiz: 'Quiz', // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	StartsWithDate: 'Starts {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	survey: 'Survey', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	totalActivities: '{count, plural, =1 {1 activity} other {{count} activities}} total', // screen reader announcement number of activities in the following list
 	upcoming: 'Upcoming Work', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork: 'View All Work', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
 	xWeeksClear: '{count, plural, =1 {1 week} other {{count} weeks}} clear!', // 'Empty state' - Header when widget has no activities to display within the next x weeks

--- a/features/workToDo/lang/en.js
+++ b/features/workToDo/lang/en.js
@@ -23,6 +23,7 @@ export default {
 	quiz: 'Quiz', // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	StartsWithDate: 'Starts {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	survey: 'Survey', // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	totalActivities: '{count, plural, =1 {1 activity} other {{count} activities}} total', // screen reader announcement number of activities in the following list
 	upcoming: 'Upcoming Work', // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork: 'View All Work', // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
 	xWeeksClear: '{count, plural, =1 {1 week} other {{count} weeks}} clear!', // 'Empty state' - Header when widget has no activities to display within the next x weeks


### PR DESCRIPTION
### Context:
[DE43323](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F601504099748&fdp=true?fdp=true)
The number in the header has not context with a screen reader. We are making it announce that "{number} activities total" for more context.

### Quality:
Tested locally.