### PR TITLE
fix: lang terms are not being used for W2D

### DIFF
--- a/features/workToDo/lang/ar.js
+++ b/features/workToDo/lang/ar.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'اكتملت الأنشطة المستحقة أو التي تنتهي بعد أسبوعين! حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'ما من أنشطة متوفرة في الوقت الحالي!', // Displayed as header line in widget text when there are no activities
 	assignment: 'الفرض',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/cy.js
+++ b/features/workToDo/lang/cy.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: "Mae gweithgareddau sy'n ddyledus neu'n dod i ben mewn pythefnos wedi’u cwblhau! Gwiriwch Gweld Pob Darn o Waith i weld beth sy'n dod yn nes ymlaen.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Dim Byd Am y Tro!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Aseiniad',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/da.js
+++ b/features/workToDo/lang/da.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Aktiviteter, der er forfaldne eller slutter om to uger, er fuldført! Kontrollér Se alle opgaver for at se, hvad der er på vej.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Alt er ryddet nu!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Opgave',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/de.js
+++ b/features/workToDo/lang/de.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'In den nächsten zwei Wochen fällige oder endende Aktivitäten sind abgeschlossen! Aktivieren Sie „Alle Arbeiten anzeigen“, um zu sehen, was danach kommt.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Soweit alles klar!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Aufgabe',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/es-es.js
+++ b/features/workToDo/lang/es-es.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Las actividades que vencen o terminan en dos semanas están completadas. Marque Ver todos los trabajos para saber lo que viene más tarde.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: '¡Todo listo por ahora!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Tarea',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/es.js
+++ b/features/workToDo/lang/es.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Se completaron las actividades pendientes o que finalizan en dos semanas. Revise la sección Ver todos los trabajos para saber lo que viene después.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: '¡Todo claro hasta ahora!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Asignación',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/fr-fr.js
+++ b/features/workToDo/lang/fr-fr.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Les activités à remettre ou se terminant dans deux semaines sont terminées ! Cochez Afficher tout le travail pour voir les activités à venir.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Il n’y a rien pour le moment !', // Displayed as header line in widget text when there are no activities
 	assignment: 'Devoir',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/fr-on.js
+++ b/features/workToDo/lang/fr-on.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Rien de plus pour l’instant!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Travail',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/fr.js
+++ b/features/workToDo/lang/fr.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: "Rien de plus pour l'instant!", // Displayed as header line in widget text when there are no activities
 	assignment: 'Travail',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/ja.js
+++ b/features/workToDo/lang/ja.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: '2 週間以内に期限を迎えるまたは終了するアクティビティは完了しました。［すべての学習の表示］をチェックして、次のアクティビティを確認してください', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: '今はすべて完了！', // Displayed as header line in widget text when there are no activities
 	assignment: '課題',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/ko.js
+++ b/features/workToDo/lang/ko.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: '2주 내에 완료되거나 끝나는 활동이 완료되었습니다! 모든 작업 보기 를 선택하여 나중에 어떤 작업을 할 수 있는지 확인합니다.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: '지금 모두 지우기!', // Displayed as header line in widget text when there are no activities
 	assignment: '과제',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/nl.js
+++ b/features/workToDo/lang/nl.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Activiteiten die de komende twee weken moeten worden uitgevoerd of beëindigd, zijn voltooid! Bekijk Al het werk weergeven om te zien wat er op komst is.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Alles is nu klaar!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Opdracht',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/pt.js
+++ b/features/workToDo/lang/pt.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'As atividades que vencem ou encerram em duas semanas estão concluídas! Marque Exibir todos os trabalhos para ver o que está por vir.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Tudo certo por enquanto!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Atividade',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/sv.js
+++ b/features/workToDo/lang/sv.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Aktiviteter som förfaller eller slutar inom två veckor är slutförda! Markera Visa alla jobb om du vill se vad som kommer längre fram.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Allt klart nu!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Uppgift',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/tr.js
+++ b/features/workToDo/lang/tr.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: 'Teslim tarihi veya sona erme tarihi iki hafta içinde olan etkinlikler tamamlandı! Daha sonraki etkinlikleri görmek için Tüm İşleri Görüntüle seçeneğini işaretleyin.', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: 'Şimdilik Her Şey Tamamlandı!', // Displayed as header line in widget text when there are no activities
 	assignment: 'Ödev',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/zh-cn.js
+++ b/features/workToDo/lang/zh-cn.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: '两周内到期或结束的活动已完成！选中“查看所有工作”以查看即将发布的工作。', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: '现在已经全部清楚！', // Displayed as header line in widget text when there are no activities
 	assignment: '作业',  // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/zh-tw.js
+++ b/features/workToDo/lang/zh-tw.js
@@ -1,4 +1,4 @@
-export const val = {
+export default {
 	activitiesAvailable: '兩週內截止的活動都已完成！請查看「檢視所有作業」，來瞭解接下來的活動。', // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear: '目前已全數清空！', // Displayed as header line in widget text when there are no activities
 	assignment: '作業',  // Meta-data descriptor that informs which type of activity is being displayed on a line item


### PR DESCRIPTION
### Context:
[DE43357](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F602042657008&fdp=true?fdp=true)
The lang terms that were taken from the activities repo have a different format than what we need for dynamic mixins. This fixes the translations to work with the mixin.

### Quality:
Tested with local build.