### PR TITLE
fix: w2d overdue order

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -70,7 +70,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 					pageSize: '_pageSize',
 					page: '_pageOverdue'
 				}],
-				method: (categories) => Object.values(categories)
+				method: (categories) => Object.keys(categories).sort().map(key => categories[key])
 			},
 			_totalActivities: {
 				type: Number,


### PR DESCRIPTION
Overdue activities no longer show up with today first.