### PR TITLE
fix: W2D. translate start date

### DIFF
--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -136,7 +136,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 
 		const startDate = (!this.actionHref && this._dates.start)
 			? html`
-				<d2l-status-indicator slot="${ ifDefined(this.collapsed ? 'supporting-info' : undefined) }" state="none" text="Starts ${formatDate(this._dates.start, {format: 'shortMonthDay'})}"></d2l-status-indicator>
+				<d2l-status-indicator slot="${ ifDefined(this.collapsed ? 'supporting-info' : undefined) }" state="none" text="${this.localize('dueWithDate', 'dueDate', formatDate(this._dates.start, {format: 'shortMonthDay'})}"></d2l-status-indicator>
 			`
 			: null;
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -136,7 +136,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 
 		const startDate = (!this.actionHref && this._dates.start)
 			? html`
-				<d2l-status-indicator slot="${ ifDefined(this.collapsed ? 'supporting-info' : undefined) }" state="none" text="${this.localize('dueWithDate', 'dueDate', formatDate(this._dates.start, {format: 'shortMonthDay'})}"></d2l-status-indicator>
+				<d2l-status-indicator slot="${ ifDefined(this.collapsed ? 'supporting-info' : undefined) }" state="none" text="${this.localize('dueWithDate', 'dueDate', formatDate(this._dates.start, {format: 'shortMonthDay'}))}"></d2l-status-indicator>
 			`
 			: null;
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -136,7 +136,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 
 		const startDate = (!this.actionHref && this._dates.start)
 			? html`
-				<d2l-status-indicator slot="${ ifDefined(this.collapsed ? 'supporting-info' : undefined) }" state="none" text="${this.localize('dueWithDate', 'dueDate', formatDate(this._dates.start, {format: 'shortMonthDay'}))}"></d2l-status-indicator>
+				<d2l-status-indicator slot="${ ifDefined(this.collapsed ? 'supporting-info' : undefined) }" state="none" text="${this.localize('StartsWithDate', 'startDate', formatDate(this._dates.start, {format: 'shortMonthDay'}))}"></d2l-status-indicator>
 			`
 			: null;
 


### PR DESCRIPTION
### Context:
[DE43357](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F602042657008&fdp=true?fdp=true)
We're missing missing translating the start date of an activity.

### Quality:
Tested with local bsi, lms, and components.