### PR TITLE
fix: pagination handles no overdue activities

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -213,6 +213,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		this.collapsed = false;
 		this._totalActivities = 0;
 		this.__currentPageOverdue = 1;
+		this._pagingTotalResultsOverdue = 0;
 		this._page = 1;
 		this.requiredPropertyForState('currentTime');
 		this.requiredPropertyForState('groupByDays');
@@ -293,7 +294,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		}
 
 		return html`
-			${overdue ? this._renderHeader2(this.localize('overdue'), this._pagingTotalResultsOverdue) : null}
+			${overdue && overdue.length !== 0 ? this._renderHeader2(this.localize('overdue'), this._pagingTotalResultsOverdue) : null}
 			${overdue}
 			${categories ? this._renderHeader2(this.localize('upcoming'), this._pagingTotalResultsUpcomming) : null}
 			${categories}
@@ -419,7 +420,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderPagination() {
 		let totalPages = Math.ceil(this._pagingTotalResultsUpcomming / this._pageSize) + Math.ceil(this._pagingTotalResultsOverdue / this._pageSize);
-		if (!this._lastOverduePageHasMoreThanHalf()) {
+		if (this._pagingTotalResultsOverdue && !this._lastOverduePageHasMoreThanHalf()) {
 			totalPages -= 1;
 		}
 		return this._loaded && !this.collapsed  ? html`

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -267,7 +267,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 				}
 				if (limit === 0) return;
 				const list = html`
-					${this._renderHeader3(header, category.count)}
+					${this._renderHeader3(header, this._pagingTotalResultsOverdue)}
 					<d2l-w2d-list href="${category.href}" .token="${this.token}" category="${category.index}" ?collapsed="${this.collapsed}" limit="${ifDefined(limit)}"></d2l-w2d-list>
 				`;
 				limit = limit === undefined ? limit : Math.max(limit - category.count, 0);
@@ -286,7 +286,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 				const header = this._renderDate(category.startDate, category.endDate, this.collapsed);
 				if (limit === 0) return;
 				const list = html`
-					${this._renderHeader3(header, this._pagingTotalResultsOverdue)}
+					${this._renderHeader3(header, category.count)}
 					<d2l-w2d-list href="${category.href}" .token="${this.token}" category="${category.index}" ?collapsed="${this.collapsed}" limit="${ifDefined(limit)}"></d2l-w2d-list>
 				`;
 				limit = limit === undefined ? limit : Math.max(limit - category.count, 0);

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -286,18 +286,21 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 				const header = this._renderDate(category.startDate, category.endDate, this.collapsed);
 				if (limit === 0) return;
 				const list = html`
-					${this._renderHeader3(header, category.count)}
+					${this._renderHeader3(header, this._pagingTotalResultsOverdue)}
 					<d2l-w2d-list href="${category.href}" .token="${this.token}" category="${category.index}" ?collapsed="${this.collapsed}" limit="${ifDefined(limit)}"></d2l-w2d-list>
 				`;
 				limit = limit === undefined ? limit : Math.max(limit - category.count, 0);
 				return list;
 			});
 		}
+		if (categories) {
+			categories = categories.filter(activity => activity !== undefined);
+		}
 
 		return html`
 			${overdue && overdue.length !== 0 ? this._renderHeader2(this.localize('overdue'), this._pagingTotalResultsOverdue) : null}
 			${overdue}
-			${categories && categories.length !== 0 ? this._renderHeader2(this.localize('upcoming'), this._pagingTotalResultsUpcoming) : null}
+			${categories && categories.length > 0 ? this._renderHeader2(this.localize('upcoming'), this._pagingTotalResultsUpcoming) : null}
 			${categories}
 			${this.dataFullPagePath && this._loaded && this.collapsed ? html`<d2l-link href="${this.dataFullPagePath}">${this.localize('fullViewLink')}</d2l-link>` : null}
 			${this._renderPagination()}

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -92,7 +92,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 			_pageUpcoming: { type: Number },
 			_pageOverdue: { type: Number },
 			_page: { type: Number },
-			_currentPageUpcomming: {
+			_currentPageUpcoming: {
 				type: Number,
 				name: 'currentPage',
 				observable: observableTypes.property,
@@ -106,7 +106,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 					page: '_pageUpcoming'
 				}]
 			},
-			_pagingTotalResultsUpcomming: {
+			_pagingTotalResultsUpcoming: {
 				type: Number,
 				name: 'pagingTotalResults',
 				observable: observableTypes.property,
@@ -213,6 +213,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		this.collapsed = false;
 		this._totalActivities = 0;
 		this.__currentPageOverdue = 1;
+		this._pagingTotalResultsUpcoming = 0;
 		this._pagingTotalResultsOverdue = 0;
 		this._page = 1;
 		this.requiredPropertyForState('currentTime');
@@ -296,7 +297,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		return html`
 			${overdue && overdue.length !== 0 ? this._renderHeader2(this.localize('overdue'), this._pagingTotalResultsOverdue) : null}
 			${overdue}
-			${categories ? this._renderHeader2(this.localize('upcoming'), this._pagingTotalResultsUpcomming) : null}
+			${categories && categories.length !== 0 ? this._renderHeader2(this.localize('upcoming'), this._pagingTotalResultsUpcoming) : null}
 			${categories}
 			${this.dataFullPagePath && this._loaded && this.collapsed ? html`<d2l-link href="${this.dataFullPagePath}">${this.localize('fullViewLink')}</d2l-link>` : null}
 			${this._renderPagination()}
@@ -419,7 +420,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 	}
 
 	_renderPagination() {
-		let totalPages = Math.ceil(this._pagingTotalResultsUpcomming / this._pageSize) + Math.ceil(this._pagingTotalResultsOverdue / this._pageSize);
+		let totalPages = Math.ceil(this._pagingTotalResultsUpcoming / this._pageSize) + Math.ceil(this._pagingTotalResultsOverdue / this._pageSize);
 		if (this._pagingTotalResultsOverdue && !this._lastOverduePageHasMoreThanHalf()) {
 			totalPages -= 1;
 		}


### PR DESCRIPTION
### Context:
[DE43416](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F602794179756&fdp=true?fdp=true)
Full screen for w2d currently displays incorrectly when there are no overdue activities for the user.

### Quality:
Tested locally.
![w2d-fullscreen-noOverdue](https://user-images.githubusercontent.com/69812595/117031798-ee870a80-acce-11eb-9618-e5945433b2db.png)
