### PR TITLE
fix: disable delete btn when user missing perm

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
@@ -71,6 +71,8 @@ class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin((L
 	}
 
 	render() {
+		// TODO: Maybe check a different action once other actions are supported to determine whether or not a quiz collection item can be selected
+		const isSelectable = this.items && this.items[0] && this.items[0].actions.includes('remove-activity');
 		return html`
 			<div class="d2l-activity-collection-body">
 				<div class="d2l-activity-collection-body-content">
@@ -83,7 +85,7 @@ class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin((L
 				<div class="d2l-activity-collection-activities">
 					<d2l-list separators="none" @d2l-list-item-position-change="${this._moveItems}" @d2l-list-selection-change="${this._onSelectionChange}">
 						${repeat(this.items, item => item.href, (item, idx) => html`
-							<d2l-activity-collection-item-quiz number="${idx + 1}" href="${item.href}" .token="${this.token}" key="${item.properties.id}"></d2l-activity-collection-item-quiz>
+							<d2l-activity-collection-item-quiz ?disabled=${!isSelectable} number="${idx + 1}" href="${item.href}" .token="${this.token}" key="${item.properties.id}"></d2l-activity-collection-item-quiz>
 						`)}
 					</d2l-list>
 				</div>

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
@@ -71,21 +71,20 @@ class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin((L
 	}
 
 	render() {
-		// TODO: Maybe check a different action once other actions are supported to determine whether or not a quiz collection item can be selected
-		const isSelectable = this.items && this.items[0] && this.items[0].actions.includes('remove-activity');
+		const canRemoveItems = this.items && this.items[0] && this.items[0].actions.includes('remove-activity');
 		return html`
 			<div class="d2l-activity-collection-body">
 				<div class="d2l-activity-collection-body-content">
 				${this.items.length ? html`
 					<div class="d2l-activity-collection-list-actions d2l-skeletize">
-						<d2l-activity-collection-item-delete-quiz selection-count="${this._selectionCount}"></d2l-activity-collection-item-delete-quiz>
+						<d2l-activity-collection-item-delete-quiz ?can-remove-items=${canRemoveItems} selection-count="${this._selectionCount}"></d2l-activity-collection-item-delete-quiz>
 					</div>
 				` : null}
 				</div>
 				<div class="d2l-activity-collection-activities">
 					<d2l-list separators="none" @d2l-list-item-position-change="${this._moveItems}" @d2l-list-selection-change="${this._onSelectionChange}">
 						${repeat(this.items, item => item.href, (item, idx) => html`
-							<d2l-activity-collection-item-quiz ?disabled=${!isSelectable} number="${idx + 1}" href="${item.href}" .token="${this.token}" key="${item.properties.id}"></d2l-activity-collection-item-quiz>
+							<d2l-activity-collection-item-quiz number="${idx + 1}" href="${item.href}" .token="${this.token}" key="${item.properties.id}"></d2l-activity-collection-item-quiz>
 						`)}
 					</d2l-list>
 				</div>

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-delete-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-delete-quiz.js
@@ -10,7 +10,8 @@ class ActivityCollectionItemDeleteQuiz extends RtlMixin(HypermediaStateMixin(Loc
 	static get properties() {
 		return {
 			_dialogOpened: { type: Boolean },
-			_selectionCount: { type: Number, attribute: 'selection-count' }
+			_selectionCount: { type: Number, attribute: 'selection-count' },
+			_canRemoveItems: { type: Boolean, attribute: 'can-remove-items'},
 		};
 	}
 	constructor() {
@@ -23,7 +24,7 @@ class ActivityCollectionItemDeleteQuiz extends RtlMixin(HypermediaStateMixin(Loc
             <d2l-button-subtle
                 text="${this.localize('button-quizEditorDelete')}"
                 icon="tier1:delete"
-                ?disabled="${this._selectionCount ? false : true}"
+                ?disabled="${this._canRemoveItems && this._selectionCount > 0 ? false : true}"
                 @click="${this._handleDialogOpen}">
             </d2l-button-subtle>
             <div class="dialog-div">


### PR DESCRIPTION
[US126706](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F519271058560&fdp=true?fdp=true): [ui] delete questions and question pools from a root level