### PR TITLE
fix: upcoming week activity count

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -286,7 +286,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 				const header = this._renderDate(category.startDate, category.endDate, this.collapsed);
 				if (limit === 0) return;
 				const list = html`
-					${this._renderHeader3(header, category.count)}
+					${this._renderHeader3(header, this._pagingTotalResultsUpcoming)}
 					<d2l-w2d-list href="${category.href}" .token="${this.token}" category="${category.index}" ?collapsed="${this.collapsed}" limit="${ifDefined(limit)}"></d2l-w2d-list>
 				`;
 				limit = limit === undefined ? limit : Math.max(limit - category.count, 0);


### PR DESCRIPTION
### Context:
[DE43466](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F603476791780&fdp=true?fdp=true)
When collapsed, we are seeing a max of 6 upcoming activities counted in the header. We want this to reflect the total number of upcoming activities.

### Quality:
Tested locally.