### PR TITLE
fix: w2d last page missing when only overdue activities

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -431,7 +431,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderPagination() {
 		let totalPages = Math.ceil(this._pagingTotalResultsUpcoming / this._pageSize) + Math.ceil(this._pagingTotalResultsOverdue / this._pageSize);
-		if (this._pagingTotalResultsOverdue && !this._lastOverduePageHasMoreThanHalf()) {
+		if (this._pagingTotalResultsOverdue && this._pagingTotalResultsUpcoming && !this._lastOverduePageHasMoreThanHalf()) {
 			totalPages -= 1;
 		}
 		if (totalPages < 1) {


### PR DESCRIPTION
### Context:
The last page is not showing up if there are only overdue activities.

Solution: only subtract if there are overdue and upcoming