### PR TITLE
fix: Add width 100% because safari is rude

### DIFF
--- a/features/workToDo/d2l-w2d-empty-state-image.js
+++ b/features/workToDo/d2l-w2d-empty-state-image.js
@@ -2,7 +2,7 @@ import { html } from 'lit-element/lit-element.js';
 
 export const img = html`
 			<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
-			viewBox="0 0 294 152.1" style="enable-background:new 0 0 294 152.1;" xml:space="preserve">
+			viewBox="0 0 294 152.1" style="enable-background:new 0 0 294 152.1; width:100%" xml:space="preserve">
 				<style type="text/css">
 					.st0{fill:#F8FAFD;}
 					.st1{clip-path:url(#SVGID_2_);}


### PR DESCRIPTION
## Context
[DE43464](https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F603463835080&fdp=true?fdp=true)
Safari decided it wants `width:100%` on the svg. Without this, there is no default width, so Safari displays nothing.

## Quality
Manual testing