### PR TITLE
fix: Use composed event for discover rules

### DIFF
--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -133,6 +133,16 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 				rules: []
 			});
 		}
+		// create a composed event so that we can catch it in the LMS
+		// we use this method until there is a hypermedia action for changing discoverability on a course
+		const event = new CustomEvent('d2l-rules-checkbox-change', {
+			bubbles: true,
+			composed: true,
+			detail: {
+				checked: e.detail.checked
+			}
+		});
+		this.dispatchEvent(event);
 	}
 
 	_onDialogClose() {

--- a/features/discover/test/d2l-discover-rules.test.js
+++ b/features/discover/test/d2l-discover-rules.test.js
@@ -103,6 +103,24 @@ describe('d2l-discover-rules', () => {
 			el = null;
 		});
 
+		it('throws an event when the checkbox is changed', async() => {
+			const checkboxDrawer = el.shadowRoot.querySelector('d2l-labs-checkbox-drawer');
+			const listener = oneEvent(el, 'd2l-rules-checkbox-change');
+			const event = new CustomEvent('d2l-checkbox-drawer-checked-change', {
+				detail: { checked: false }
+			});
+			checkboxDrawer.dispatchEvent(event);
+			checkboxDrawer.checked = false;
+			await listener;
+			await el.updateComplete;
+			const expectedCommit = {
+				rules: []
+			};
+			expect(commitSpy.calledOnce, 'commit was not called').to.be.true;
+			expect(commitSpy.calledWith(expectedCommit), `commit was not called with: ${expectedCommit}`).to.be.true;
+			expect(el._rules, 'rules should not be removed').to.have.lengthOf(1);
+		});
+
 		it('removes a rule when the delete menu item is clicked', async() => {
 			expect(el._rules).to.have.lengthOf(1);
 			const card = el.shadowRoot.querySelector('d2l-discover-rule-card');


### PR DESCRIPTION
## Context
The checkbox portion of the component in the LMS is not behaving as expected because the current event it is attempting to catch, `d2l-checkbox-drawer-checked-change`, is not `composed`. Composed events are able to pierce the shadow DOM.

- Adds a new bubbling, composed event: `d2l-rules-checkbox-change`

## Quality
- New unit test added