### PR TITLE
fix: Use bypassCache argument in match count summon

### DIFF
--- a/features/discover/mixins/match-count-mixin.js
+++ b/features/discover/mixins/match-count-mixin.js
@@ -25,7 +25,7 @@ export const MatchCountMixin = superclass => class extends superclass {
 	async getMatchData(summonAction, conditions, includeUsers, userLimit) {
 		const conditionFilter = this.createConditionFilter(conditions, includeUsers, userLimit);
 		if (conditionFilter.match.length > 0) {
-			const sirenReponse = await summonAction.summon(conditionFilter);
+			const sirenReponse = await summonAction.summon(conditionFilter, true);
 			if (sirenReponse) {
 				return {
 					count: sirenReponse.properties.count,


### PR DESCRIPTION
With the [engine PR](https://github.com/BrightspaceHypermediaComponents/foundation-engine/pull/102) merged, this PR updates the `match-count-mixin` to use the new bypassCache argument and retrieve an uncached match count.