### PR TITLE
Downgrade eslint-plugin-lit to stable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^7",
     "eslint-config-brightspace": "^0.13",
     "eslint-plugin-html": "^6",
-    "eslint-plugin-lit": "^1",
+    "eslint-plugin-lit": "1.4.1",
     "eslint-plugin-sort-class-members": "^1.11.0",
     "fetch-mock": "^9.11.0",
     "karma-sauce-launcher": "^2",


### PR DESCRIPTION
eslint-plugin-lit release version 1.5, which is causing syntax errors during PR linting. Downgrading to 1.4.1 for now