### PR TITLE
Update activities to use the LabelMixin

### DIFF
--- a/components/activity/name/custom/d2l-activity-name-assignment.js
+++ b/components/activity/name/custom/d2l-activity-name-assignment.js
@@ -2,12 +2,13 @@ import '../../../common/d2l-hc-name.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	assignment: 'https://api.brightspace.com/rels/assignment'
 });
 
-export class ActivityNameAssignment extends HypermediaStateMixin(LitElement) {
+export class ActivityNameAssignment extends LabelMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
 			_assignmentHref: { type: String, observable: observableTypes.link, rel: rels.assignment, prime: true }

--- a/components/activity/name/custom/d2l-activity-name-checklist.js
+++ b/components/activity/name/custom/d2l-activity-name-checklist.js
@@ -2,12 +2,13 @@ import '../../../common/d2l-hc-name.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	checklist: 'https://checklists.api.brightspace.com/rels/checklist-item'
 });
 
-export class ActivityNameChecklist extends HypermediaStateMixin(LitElement) {
+export class ActivityNameChecklist extends LabelMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
 			_checklistHref: { type: String, observable: observableTypes.link, rel: rels.checklist, prime: true }

--- a/components/activity/name/custom/d2l-activity-name-content.js
+++ b/components/activity/name/custom/d2l-activity-name-content.js
@@ -2,12 +2,13 @@ import '../../../common/d2l-hc-name.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	content: 'https://api.brightspace.com/rels/content'
 });
 
-export class ActivityNameContent extends HypermediaStateMixin(LitElement) {
+export class ActivityNameContent extends LabelMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
 			_title: { type: String, observable: observableTypes.property, route: [{observable: observableTypes.link, rel: rels.content}] },

--- a/components/activity/name/custom/d2l-activity-name-course.js
+++ b/components/activity/name/custom/d2l-activity-name-course.js
@@ -2,12 +2,14 @@ import '../../../common/d2l-hc-name.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	organization: 'https://api.brightspace.com/rels/organization'
 });
 
-export class ActivityNameCourse extends HypermediaStateMixin(LitElement) {
+export class ActivityNameCourse extends LabelMixin(HypermediaStateMixin(LitElement)) {
+
 	static get properties() {
 		return {
 			_organizationHref: { type: String, observable: observableTypes.link, rel: rels.organization, prime: true }

--- a/components/activity/name/custom/d2l-activity-name-discussion.js
+++ b/components/activity/name/custom/d2l-activity-name-discussion.js
@@ -2,12 +2,13 @@ import '../../../common/d2l-hc-name.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	topic: 'https://discussions.api.brightspace.com/rels/topic'
 });
 
-export class ActivityNameDiscussion extends HypermediaStateMixin(LitElement) {
+export class ActivityNameDiscussion extends LabelMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
 			_topicHref: { type: String, observable: observableTypes.link, rel: rels.topic, prime: true }

--- a/components/activity/name/custom/d2l-activity-name-quiz.js
+++ b/components/activity/name/custom/d2l-activity-name-quiz.js
@@ -2,12 +2,13 @@ import '../../../common/d2l-hc-name.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	quiz: 'https://api.brightspace.com/rels/quiz'
 });
 
-export class ActivityNameQuiz extends HypermediaStateMixin(LitElement) {
+export class ActivityNameQuiz extends LabelMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
 			_quizHref: { type: String, observable: observableTypes.link, rel: rels.quiz, prime: true }

--- a/components/activity/name/custom/d2l-activity-name-specialization.js
+++ b/components/activity/name/custom/d2l-activity-name-specialization.js
@@ -4,12 +4,13 @@ import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	specialization: 'https://api.brightspace.com/rels/specialization'
 });
 
-class ActivityNameSpecialization extends HypermediaStateMixin(LitElement) {
+class ActivityNameSpecialization extends LabelMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
 			_specializationHref: { type: String, observable: observableTypes.link, rel: rels.specialization, prime: true }

--- a/components/activity/name/custom/d2l-activity-name-survey.js
+++ b/components/activity/name/custom/d2l-activity-name-survey.js
@@ -2,12 +2,13 @@ import '../../../common/d2l-hc-name.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { customHypermediaElement } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 
 const rels = Object.freeze({
 	survey: 'https://surveys.api.brightspace.com/rels/survey'
 });
 
-export class ActivityNameSurvey extends HypermediaStateMixin(LitElement) {
+export class ActivityNameSurvey extends LabelMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
 			_surveyHref: { type: String, observable: observableTypes.link, rel: rels.survey, prime: true }

--- a/components/common/d2l-hc-name.js
+++ b/components/common/d2l-hc-name.js
@@ -32,6 +32,16 @@ class HmName extends SkeletonMixin(HypermediaStateMixin(LocalizeCommon(LitElemen
 		return html`<span class="d2l-skeletize">${this.name ? this.name : html`${this.localize('name')} <div class="d2l-activity-name-skeleton-extend-skeleton-width"></div>`}</span>`;
 	}
 
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (!changedProperties.has('name')) return;
+		this.dispatchEvent(new CustomEvent('d2l-label-change', {
+			bubbles: true,
+			composed: true,
+			detail: this.name
+		}));
+	}
+
 	get _loaded() {
 		return !this.skeleton;
 	}

--- a/features/lti/d2l-lti-activity.js
+++ b/features/lti/d2l-lti-activity.js
@@ -7,6 +7,7 @@ import { bodyCompactStyles, bodySmallStyles, heading3Styles } from '@brightspace
 import { css, LitElement } from 'lit-element/lit-element.js';
 import { HypermediaStateMixin, observableTypes } from '@brightspace-hmc/foundation-engine/framework/lit/HypermediaStateMixin.js';
 import { html } from '@brightspace-hmc/foundation-engine/framework/lit/hypermedia-components.js';
+import { LabelMixin } from '@brightspace-ui/core/mixins/labelled-mixin.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
@@ -14,7 +15,7 @@ const rels = Object.freeze({
 	linkPlacement: 'https://lti.api.brightspace.com/rels/link-placement'
 });
 
-class LtiActivity extends SkeletonMixin(LocalizeDynamicMixin(HypermediaStateMixin(LitElement))) {
+class LtiActivity extends SkeletonMixin(LocalizeDynamicMixin(LabelMixin(HypermediaStateMixin(LitElement)))) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
This PR updates activities to extend the core `LabelMixin` so that these components can be referenced as labels for list-items and other future selectable components such as in tables. 

I initially went down the path of the factoring the contents of `d2l-hc-name` into a mixin in order to "flatten" the components and enable the `updateLabel()` call, however the Lti case is more than just a name, and in such cases it "has a" name, rather than "is a" name, so extending a name mixin doesn't make sense.

Ref: https://github.com/BrightspaceUI/core/pull/1399