### PR TITLE
US129210 Add existing activity usages to quiz

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
@@ -112,7 +112,7 @@ class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin(Li
 		`;
 	}
 	async addToCollection(activityHrefs) {
-		if (!this._hasAction('_startAddExisting')) {
+		if (!activityHrefs || !activityHrefs.length || !this._hasAction('_startAddExisting')) {
 			return;
 		}
 

--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-editor-quiz.js
@@ -11,6 +11,7 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 
 const rels = Object.freeze({
 	collection: 'https://activities.api.brightspace.com/rels/activity-collection',
+	activityUsage: 'https://activities.api.brightspace.com/rels/activity-usage',
 	item: 'item'
 });
 
@@ -19,7 +20,7 @@ const route = {
 		{ observable: observableTypes.link, rel: rels.collection }
 };
 
-class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin((LitElement))) {
+class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -34,6 +35,19 @@ class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin((L
 				type: Object,
 				observable: observableTypes.refreshState,
 				route: [route.collection]
+			},
+			_startAddExisting: {
+				observable: observableTypes.summonAction,
+				name: 'start-add-existing-activity',
+				route: [route.collection]
+			},
+			_startAddExistingExecuteMultiple: {
+				observable: observableTypes.summonAction,
+				name: 'execute-multiple',
+				route: [
+					route.collection,
+					{ observable: observableTypes.summonAction, name: 'start-add-existing-activity' }
+				]
 			}
 		};
 	}
@@ -96,6 +110,37 @@ class ActivityCollectionEditorQuiz extends SkeletonMixin(HypermediaStateMixin((L
 				</div>
 			</div>
 		`;
+	}
+	async addToCollection(activityHrefs) {
+		if (!this._hasAction('_startAddExisting')) {
+			return;
+		}
+
+		const summoned = await this._startAddExisting.summon({}, true);
+		const candidates = summoned.entities;
+
+		if (!this._hasAction('_startAddExistingExecuteMultiple')) {
+			return;
+		}
+
+		const actionStates = [];
+		const activityUsageLink = item => item.links.find(link => link.rel.includes(rels.activityUsage)).href;
+		for (const activityHref of activityHrefs) {
+			const candidate = candidates.find(e => activityUsageLink(e) === activityHref);
+			if (candidate && candidate.properties && candidate.properties.actionState) {
+				actionStates.push(candidate.properties.actionState);
+			}
+		}
+
+		if (!actionStates.length) {
+			return;
+		}
+
+		await this._startAddExistingExecuteMultiple.summon({
+			actionStates: actionStates.join()
+		});
+
+		this._refreshState();
 	}
 	get _loaded() {
 		return !this.skeleton;


### PR DESCRIPTION
Use start-add-existing-activity and execute-multiple to add predefined list of activity usage hrefs.

Related PR in activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/1836

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F601851661777