### PR TITLE
Pass upcoming weeks limit from LMS.

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -39,6 +39,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 			startDate: { type: String, attribute: 'start-date' },
 			endDate: { type: String, attribute: 'end-date' },
 			dataFullPagePath: { type: String, attribute: 'data-full-page-path' },
+			upcomingWeekLimit: { type: String, attribute: 'upcoming-week-limit' },
 			skeleton: { type: Boolean, reflect: true },
 			userUrl: { type: String, attribute: 'user-url' },
 			_categories: {
@@ -302,6 +303,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 					?complete="${!this.collapsed}"
 					?use-first-name="${this.useFirstName}"
 					data-full-page-path=${this.dataFullPagePath}
+					upcoming-week-limit="${this.upcomingWeekLimit}"
 					.token="${this.token}"
 					href=${this.userUrl}></d2l-w2d-no-activities>
 			`;

--- a/features/workToDo/d2l-w2d-no-activities.js
+++ b/features/workToDo/d2l-w2d-no-activities.js
@@ -27,7 +27,7 @@ class w2dNoActivities extends LocalizeDynamicMixin(HypermediaStateMixin(LitEleme
 			},
 			upcomingWeekLimit: {
 				type: Number,
-				attribute: "upcoming-week-limit",
+				attribute: 'upcoming-week-limit',
 			}
 		};
 	}

--- a/features/workToDo/d2l-w2d-no-activities.js
+++ b/features/workToDo/d2l-w2d-no-activities.js
@@ -5,7 +5,6 @@ import { img } from './d2l-w2d-empty-state-image.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 
-const weekCount = 2;
 const rels = Object.freeze({
 	firstName: 'https://api.brightspace.com/rels/first-name'
 });
@@ -25,6 +24,10 @@ class w2dNoActivities extends LocalizeDynamicMixin(HypermediaStateMixin(LitEleme
 				method: (firstName) => {
 					return firstName?.[0]?.properties.name;
 				}
+			},
+			upcomingWeekLimit: {
+				type: Number,
+				attribute: "upcoming-week-limit",
 			}
 		};
 	}
@@ -167,7 +170,7 @@ class w2dNoActivities extends LocalizeDynamicMixin(HypermediaStateMixin(LitEleme
 
 	_renderEmptyViewHeader()  {
 		const emptyViewHeader = this.activities ?
-			this.localize('xWeeksClear', 'count', weekCount) :
+			this.localize('xWeeksClear', 'count', this.upcomingWeekLimit) :
 			this.localize('allClear');
 
 		return html`

--- a/features/workToDo/d2l-w2d-work-to-do.js
+++ b/features/workToDo/d2l-w2d-work-to-do.js
@@ -30,6 +30,7 @@ class w2dWorkToDo extends LocalizeDynamicMixin(HypermediaStateMixin(LitElement))
 			startDate: { type: String, attribute: 'start-date' },
 			endDate: { type: String, attribute: 'end-date' },
 			overdueWeekLimit: { type: Number, attribute: 'data-overdue-week-limit' },
+			upcomingWeekLimit: { type: String, attribute: 'data-upcoming-week-limit' },
 			_myActivitiesHref: { type: String, observable: observableTypes.link, rel: rel.myActivities, prime: true },
 			_myOrganizationActivitiesHref: { type: String, observable: observableTypes.link, rel: rel.myOrganizationActivities, prime: true },
 			_organizationHompage: { type: String, observable: observableTypes.link, rel: rel.organizationHomepage },
@@ -125,6 +126,7 @@ class w2dWorkToDo extends LocalizeDynamicMixin(HypermediaStateMixin(LitElement))
 				data-full-page-path=${ifDefined(this.dataFullPagePath)}
 				?use-first-name=${this.useFirstName}
 				overdue-day-limit="${this.overdueWeekLimit * 7}"
+				upcoming-week-limit="${this.upcomingWeekLimit}"
 				?skeleton="${!this._loaded}"
 				user-url="${this.href}"
 				?allow-unclickable-activities="${this.allowUnclickableActivities}"></d2l-w2d-collections>


### PR DESCRIPTION
## Overview
![image](https://user-images.githubusercontent.com/34746763/123444165-98cf3000-d5a4-11eb-9660-e6be3f9fdb2a.png)

This "N weeks clear!" string will now respect the UpcomingWeekLimit config variable.

### Reason for change

See Rally Ticket: [DE43699](https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fdefect%2F605988636084&view=aea56dea-ee73-4c07-9842-cc15d4efc0ea&fdp=true?fdp=true): 1. W2D only displays 2 weeks clear graphic despite config setting

### Changes summarized

- Main w2d component passes data from LMS
- Collections w2d component passes data to no-activities component
- Replace hardcoded value in no-activities component with passed-in attribute

### Suggested future tasks

None.

## Checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job