### PR TITLE
Add screen reader only text.

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -422,7 +422,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderHeader3(heading, count) {
 		if (!this.collapsed) return html`<div class="d2l-w2d-flex"><h3 class="d2l-w2d-heading-3">${heading}</h3></div>`;
-		const screenReaderText = this.localize('xActivities', 'count', count)
+		const screenReaderText = this.localize('xActivities', 'count', count);
 		return html`
 			<div class="d2l-w2d-flex">
 				<h3 class="d2l-w2d-heading-3 d2l-heading-3">${heading}</h3>

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -412,6 +412,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderHeader2(heading, count) {
 		if (this.collapsed) return;
+		const screenReaderText = this.localize('xActivities', 'count', count);
 		return html`
 			<div class="d2l-w2d-flex">
 				<h2 class="d2l-heading-2">${heading}</h2>

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -422,10 +422,11 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 	_renderHeader3(heading, count) {
 		if (!this.collapsed) return html`<div class="d2l-w2d-flex"><h3 class="d2l-w2d-heading-3">${heading}</h3></div>`;
+		const screenReaderText = this.localize('xActivities', 'count', count)
 		return html`
 			<div class="d2l-w2d-flex">
 				<h3 class="d2l-w2d-heading-3 d2l-heading-3">${heading}</h3>
-				<div class="d2l-w2d-count d2l-w2d-heading-3-count">${count}</div>
+				<div class="d2l-w2d-count d2l-w2d-heading-3-count" aria-label="${screenReaderText}"><span aria-hidden="true">${count}</span></div>
 			</div>
 		`;
 	}

--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -415,7 +415,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 		return html`
 			<div class="d2l-w2d-flex">
 				<h2 class="d2l-heading-2">${heading}</h2>
-				<div class="d2l-w2d-count d2l-w2d-heading-2-count">${count}</div>
+				<div class="d2l-w2d-count d2l-w2d-heading-2-count" aria-label="${screenReaderText}"><span aria-hidden="true">${count}</span></div>
 			</div>
 		`;
 	}

--- a/features/workToDo/lang/en-us.js
+++ b/features/workToDo/lang/en-us.js
@@ -27,6 +27,7 @@ export default {
 	noActivitiesNoFutureActivitiesNameless: 'There are no activities with due or end dates available. Come back later to see if there is work to do.', // Shown under the same conditions as noActivitiesNoFutureActivities, when we want to refer to the user in the third person but don't know their name
 	nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue: 'Overdue', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	xActivities: '{count, plural, =1 {1 activity} other {{count} activities}}', // Label text for pluralizing activites.
 	quiz: 'Quiz', // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	StartsWithDate: 'Starts {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	survey: 'Survey', // Meta-data descriptor that informs which type of activity is being displayed on a line item

--- a/features/workToDo/lang/en.js
+++ b/features/workToDo/lang/en.js
@@ -26,6 +26,7 @@ export default {
 	noActivitiesNoFutureActivitiesNameless: 'There are no activities with due or end dates available. Come back later to see if there is work to do.', // Shown under the same conditions as noActivitiesNoFutureActivities, when we want to refer to the user in the third person but don't know their name
 	nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue: 'Overdue', // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	xActivities: '{count, plural, =1 {1 activity} other {{count} activities}}', // Label text for pluralizing activites.
 	quiz: 'Quiz', // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	StartsWithDate: 'Starts {startDate}', // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	survey: 'Survey', // Meta-data descriptor that informs which type of activity is being displayed on a line item


### PR DESCRIPTION
## Overview
![image](https://user-images.githubusercontent.com/34746763/123455934-4562df00-d5b0-11eb-95d4-498c57da41aa.png)

Add description for screen readers.

### Reason for change

See ticket: [DE43323](https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fdefect%2F601504099748&view=aea56dea-ee73-4c07-9842-cc15d4efc0ea&fdp=true?fdp=true): 3. Screen reader announcing number of activties

### Changes summarized

- Add sr-only text using `aria-label`
- Hide original text from screen reader using `aria-hidden`

### Suggested future tasks

None.

## Checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job