### PR TITLE
US128094 Add start/end date observers

### DIFF
--- a/features/workToDo/w2dSummonActionObserver.js
+++ b/features/workToDo/w2dSummonActionObserver.js
@@ -19,6 +19,8 @@ export class W2dSummonAction extends SirenSummonAction {
 		}
 		super.addObserver(observer, property, { method, route });
 		this._setPage(observer[page]);
+		this._setStartDate(observer[start]);
+		this._setEndDate(observer[end]);
 	}
 
 	get method() {
@@ -42,11 +44,23 @@ export class W2dSummonAction extends SirenSummonAction {
 		this._fields = this._decodeFields(this._rawSirenAction);
 		this._method = this._rawSirenAction.method;
 		if (this._routes.size > 0) {
-			this.routedState = await this.createRoutedState(this.href, this._token.rawToken);
-			this._routes.forEach((route, observer) => {
-				this.routedState.addObservables(observer, route);
-			});
-			await fetch(this.routedState);
+			await this._fetchRoutedState();
+		}
+	}
+
+	async _fetchRoutedState() {
+		this.routedState = await this.createRoutedState(this.href, this._token.rawToken);
+		this._routes.forEach((route, observer) => {
+			this.routedState.addObservables(observer, route);
+		});
+		await fetch(this.routedState);
+	}
+
+	async _setEndDate(endDate) {
+		if (!endDate || this._endDate === endDate) return;
+		this._endDate = endDate;
+		if (this._routes.size > 0 && this._href && this._token) {
+			await this._fetchRoutedState();
 		}
 	}
 
@@ -54,11 +68,15 @@ export class W2dSummonAction extends SirenSummonAction {
 		if (!page || this._page === page) return;
 		this._page = page;
 		if (this._routes.size > 0 && this._href && this._token) {
-			this.routedState = await this.createRoutedState(this.href, this._token.rawToken);
-			this._routes.forEach((route, observer) => {
-				this.routedState.addObservables(observer, route);
-			});
-			await fetch(this.routedState);
+			await this._fetchRoutedState();
+		}
+	}
+
+	async _setStartDate(startDate) {
+		if (!startDate || this._startDate === startDate) return;
+		this._startDate = startDate;
+		if (this._routes.size > 0 && this._href && this._token) {
+			await this._fetchRoutedState();
 		}
 	}
 }

--- a/features/workToDo/w2dSummonActionObserver.js
+++ b/features/workToDo/w2dSummonActionObserver.js
@@ -43,40 +43,36 @@ export class W2dSummonAction extends SirenSummonAction {
 		this._href = this._rawSirenAction.href;
 		this._fields = this._decodeFields(this._rawSirenAction);
 		this._method = this._rawSirenAction.method;
-		if (this._routes.size > 0) {
-			await this._fetchRoutedState();
-		}
+		await this._fetchRoutedState();
 	}
 
 	async _fetchRoutedState() {
-		this.routedState = await this.createRoutedState(this.href, this._token.rawToken);
-		this._routes.forEach((route, observer) => {
-			this.routedState.addObservables(observer, route);
-		});
-		await fetch(this.routedState);
+		if (this._routes.size > 0 && this._href && this._token) {
+			this.routedState = await this.createRoutedState(this.href, this._token.rawToken);
+			this._routes.forEach((route, observer) => {
+				this.routedState.addObservables(observer, route);
+			});
+			await fetch(this.routedState);
+		}
 	}
 
 	async _setEndDate(endDate) {
 		if (!endDate || this._endDate === endDate) return;
 		this._endDate = endDate;
-		if (this._routes.size > 0 && this._href && this._token) {
-			await this._fetchRoutedState();
-		}
+		if (!this._startDate) return;
+		await this._fetchRoutedState();
 	}
 
 	async _setPage(page) {
 		if (!page || this._page === page) return;
 		this._page = page;
-		if (this._routes.size > 0 && this._href && this._token) {
-			await this._fetchRoutedState();
-		}
+		await this._fetchRoutedState();
 	}
 
 	async _setStartDate(startDate) {
 		if (!startDate || this._startDate === startDate) return;
 		this._startDate = startDate;
-		if (this._routes.size > 0 && this._href && this._token) {
-			await this._fetchRoutedState();
-		}
+		if (!this._endDate) return;
+		await this._fetchRoutedState();
 	}
 }


### PR DESCRIPTION
As part of adding the new W2D component to Brightspace for Parents, we need to be able to change the date range W2D is showing, as this was a feature of the old upcoming work widget in BfP. W2D mostly works in this regard, but it doesn't fetch the new date range when an updated start/end date is set on it. This change resolves that by re-fetching whenever these parameters change.

This also includes a minor refactor by moving some common behaviour into `_fetchRoutedState`, as it was needed by two existing functions, as well as the two new ones.