### PR TITLE
Hide "View All Work" button from empty state

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -302,7 +302,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 					?collapsed="${this.collapsed}"
 					?complete="${!this.collapsed}"
 					?use-first-name="${this.useFirstName}"
-					data-full-page-path=${this.dataFullPagePath}
+					data-full-page-path="${ifDefined(this.dataFullPagePath)}"
 					upcoming-week-limit="${this.upcomingWeekLimit}"
 					.token="${this.token}"
 					href=${this.userUrl}></d2l-w2d-no-activities>

--- a/features/workToDo/d2l-w2d-no-activities.js
+++ b/features/workToDo/d2l-w2d-no-activities.js
@@ -155,7 +155,7 @@ class w2dNoActivities extends LocalizeDynamicMixin(HypermediaStateMixin(LitEleme
 	}
 
 	_renderEmptyViewButton() {
-		if (!this.activities) {
+		if (!this.activities || !this.dataFullPagePath) {
 			return undefined;
 		}
 		return html`


### PR DESCRIPTION
The "View All Work" button is being correctly hidden [in `d2l-w2d-collections`](https://github.com/BrightspaceHypermediaComponents/foundation-components/blob/65c3e3a7544907be18ed4a05b92b59a40af50667/features/workToDo/d2l-w2d-collections.js#L294) when the `dataFullPagePage` is not set. This just adds similar behavior to the empty state `d2l-w2d-no-activities` component, so that it doesn't display a "View All Work" button if there is nowhere for the button to go.