### PR TITLE
Testing strategy for components

### DIFF
--- a/components/activity/code/test/d2l-activity-code-editor.test.js
+++ b/components/activity/code/test/d2l-activity-code-editor.test.js
@@ -1,14 +1,45 @@
 import '../d2l-activity-code-editor.js';
 import '../custom/d2l-activity-code-editor-learning-path.js';
-import { addToMock, mockLink } from '../../../../test/data/fetchMock.js';
 import { assert, html } from '@open-wc/testing';
 import { createComponentAndWait, fireEventAndWait } from '../../../../test/test-util.js';
-import { learningPathExisting, learningPathMissingAction, learningPathNew } from '../../../../test/data/learningPath.js';
 import { clearStore } from '@brightspace-hmc/foundation-engine/state/HypermediaState.js';
+import fetchMock from 'fetch-mock/esm/client';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 import sinon from 'sinon/pkg/sinon-esm.js';
 
-const inputText = 'd2l-input-text';
+fetchMock.config.overwriteRoutes = true;
+
+const inputText = 'd2l-input-text',
+	activityHref = 'http://activity/',
+	orgHref = 'http://org/';
+
+const activity = {
+	class:['activity'],
+	links:[
+		{
+			'rel':['self'],
+			'href':'/components/activity/code/demo/activity.json'
+		}, {
+			'rel': ['https://api.brightspace.com/rels/organization'],
+			'href': orgHref
+		}
+	]
+};
+
+const org = {
+	properties: {
+		'code': 'Code'
+	},
+	actions: [
+		{ 'href':'http:/update/code',  'name':'update-code',  'method':'PATCH',  'fields':[ { 'class':['required'],  'type':'text',  'name':'code',  'value':'LP' } ] },
+	]
+};
+
+const orgNoAction = {
+	properties: {
+		'code': 'Code'
+	}
+};
 
 async function _createCodeEditor(path) {
 	return await createComponentAndWait(html`<d2l-activity-code-editor href="${path}" token="test-token"></d2l-activity-code-editor>`);
@@ -27,14 +58,13 @@ async function updateCode(element, updatedText) {
 
 describe('d2l-activity-code-editor', async() => {
 
-	before(async() => {
-		mockLink.reset();
-		await addToMock('/learning-path/new', learningPathNew, _createCodeEditorLearningPath);
-		await addToMock('/learning-path/existing', learningPathExisting, _createCodeEditorLearningPath);
-		await addToMock('/learning-path/missing-action', learningPathMissingAction, _createCodeEditorLearningPath);
+	before(() => {
+		fetchMock.mock(activityHref, JSON.stringify(activity))
+			.mock(orgHref, JSON.stringify(org));
 	});
+
 	after(() => {
-		mockLink.reset();
+		fetchMock.reset();
 	});
 
 	describe('constructor', () => {
@@ -50,29 +80,18 @@ describe('d2l-activity-code-editor', async() => {
 			clearStore();
 		});
 
-		afterEach(() => {
-			mockLink.resetHistory();
-		});
-
-		it('should initialize using defined path and expected values', async() => {
-			const element = await _createCodeEditor('/learning-path/new');
-
-			assert.equal(element.code, learningPathNew.properties.code);
-		});
-
-		describe('path:/learning-path/existing', () => {
+		describe('Code', () => {
 			let element;
 			beforeEach(async() => {
 				clearStore();
-				element = await _createCodeEditor('/learning-path/existing');
-				assert.equal(element.code, learningPathExisting.properties.code, 'code should match response');
+				element = await _createCodeEditor(activityHref);
 			});
 
 			it('code should be set when one is present', () => {
 				assert.equal(element.shadowRoot.querySelector(inputText).value,
-					learningPathExisting.properties.code, 'input value does not match');
+					org.properties.code, 'input value does not match');
 
-				assert.equal(element.code, learningPathExisting.properties.code, 'code property should match');
+				assert.equal(element.code, org.properties.code, 'code property should match');
 
 			});
 
@@ -100,18 +119,20 @@ describe('d2l-activity-code-editor', async() => {
 				assert.isTrue(spy.commit.called, 'commit should be called when input event is triggered');
 			});
 		});
-		describe('path:/learning-path/missing-action', () => {
-			let element;
-			beforeEach(async() => {
-				clearStore();
-				element = await _createCodeEditor('learning-path/missing-action');
-				assert.equal(element.code, learningPathMissingAction.properties.code, 'code should match response');
-			});
+
+		describe('Update code action missing', () => {
+
 			it('code not updated when action missing', async() => {
+				fetchMock.mock(orgHref, JSON.stringify(orgNoAction));
+
+				clearStore();
+				const element = await _createCodeEditor(activityHref);
+				assert.equal(element.code, org.properties.code, 'code should match response');
+
 				const spy = sinon.spy(element.updateCode);
 				await updateCode(element, 'new code');
 
-				assert.equal(element.code, learningPathMissingAction.properties.code, 'code was unaltered');
+				assert.equal(element.code, org.properties.code, 'code was unaltered');
 				assert.isFalse(spy.commit.called, 'commit should not be called on update failure');
 			});
 		});
@@ -121,13 +142,11 @@ describe('d2l-activity-code-editor', async() => {
 describe('d2l-activity-code-editor-learning-path', () => {
 
 	before(async() => {
-		mockLink.reset();
-		await addToMock('/learning-path/new', learningPathNew, _createCodeEditorLearningPath, false);
-		await addToMock('/learning-path/existing', learningPathExisting, _createCodeEditorLearningPath, false);
-		await addToMock('/learning-path/missing-action', learningPathMissingAction, _createCodeEditorLearningPath, false);
+		fetchMock.mock(activityHref, JSON.stringify(activity))
+			.mock(orgHref, JSON.stringify(org));
 	});
 	after(() => {
-		mockLink.reset();
+		fetchMock.reset();
 	});
 
 	describe('constructor', () => {
@@ -143,29 +162,18 @@ describe('d2l-activity-code-editor-learning-path', () => {
 			clearStore();
 		});
 
-		afterEach(() => {
-			mockLink.resetHistory();
-		});
-
-		it('should initialize using defined path and expected values', async() => {
-			const element = await _createCodeEditorLearningPath('/learning-path/new');
-
-			assert.equal(element.code, learningPathNew.properties.code);
-		});
-
 		describe('path:/learning-path/existing', () => {
 			let element;
 			beforeEach(async() => {
 				clearStore();
-				element = await _createCodeEditorLearningPath('/learning-path/existing');
-				assert.equal(element.code, learningPathExisting.properties.code, 'code should match response');
+				element = await _createCodeEditorLearningPath(activityHref);
 			});
 
 			it('code should be set when one is present', () => {
 				assert.equal(element.shadowRoot.querySelector(inputText).value,
-					learningPathExisting.properties.code, 'input value does not match');
+					org.properties.code, 'input value does not match');
 
-				assert.equal(element.code, learningPathExisting.properties.code, 'code property should match');
+				assert.equal(element.code, org.properties.code, 'code property should match');
 
 			});
 
@@ -198,18 +206,17 @@ describe('d2l-activity-code-editor-learning-path', () => {
 			});
 			*/
 		});
-		describe('path:/learning-path/missing-action', () => {
-			let element;
-			beforeEach(async() => {
-				clearStore();
-				element = await _createCodeEditorLearningPath('learning-path/missing-action');
-				assert.equal(element.code, learningPathMissingAction.properties.code, 'code should match response');
-			});
+		describe('Missing Action ', () => {
 			it('code not updated when action missing', async() => {
+				fetchMock.mock(orgHref, JSON.stringify(orgNoAction));
+
+				const element = await _createCodeEditorLearningPath(activityHref);
+				assert.equal(element.code, org.properties.code, 'code should match response');
+
 				const spy = sinon.spy(element.updateCode);
 				await updateCode(element, 'new code');
 
-				assert.equal(element.code, learningPathMissingAction.properties.code, 'code was unaltered');
+				assert.equal(element.code, org.properties.code, 'code was unaltered');
 				assert.isFalse(spy.commit.called, 'commit should not be called on update failure');
 			});
 		});

--- a/test/testTemplate.js
+++ b/test/testTemplate.js
@@ -1,8 +1,7 @@
 import { assert, html } from '@open-wc/testing';
-import { addToMock } from './data/fetchMock.js';
 import { clearStore } from '@brightspace-hmc/foundation-engine/state/HypermediaState.js';
 import { createComponentAndWait } from '../../test-util.js';
-import { mockLink } from '../../data/fetchMocks.js';
+import fetchMock from 'fetch-mock/esm/client';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
 
 // to be imported: component implementation file, testing data
@@ -12,16 +11,20 @@ async function _createComponent(path) {
 	return await createComponentAndWait(html`<tag href="${path}" token="test-token"></tag>`);
 }
 
+const apiHref = 'http://api/';
+const responseData = {
+	properties: {
+		name: 'test'
+	}
+};
+
 describe('component-name', () => {
 
 	before(() => {
-		mockLink.reset();
-		// add appropriate data to fetch mock
-		//addToMock('path', jsonResponse);
-		addToMock();
+		fetchMock.mock(apiHref, responseData);
 	});
 	after(() => {
-		mockLink.reset();
+		fetchMock.reset();
 	});
 
 	describe('construction', () => {
@@ -39,11 +42,11 @@ describe('component-name', () => {
 		});
 
 		afterEach(() => {
-			mockLink.resetHistory();
+			fetchMock.resetHistory();
 		});
 
 		it('should initialize using ...', async() => {
-			const element = await _createComponent('ref');
+			const element = await _createComponent(apiHref);
 
 			// assert fields are assigned as desired
 			assert(element);
@@ -58,11 +61,11 @@ describe('component-name', () => {
 		});
 
 		afterEach(() => {
-			mockLink.resetHistory();
+			fetchMock.resetHistory();
 		});
 
 		it('should ...', async() => {
-			await _createComponent('path');
+			await _createComponent(apiHref);
 		});
 	});
 });


### PR DESCRIPTION
```Context```
I had an idea of creating generic testing data that could be reused for components, but thinking this is more confusing / complex than it should be. In addition the AddMock util was only good for learning paths use case. Defining mocks inside the tests with the data seems to be a better approach, so I am updated the testTemplate and started to cleanup the tests.

Leaving the PR where it is for now to discuss if this is the approach we should follow. 