### PR TITLE
DE44196 Fix due date being cut off

### DIFF
--- a/features/workToDo/d2l-w2d-attribute-list.js
+++ b/features/workToDo/d2l-w2d-attribute-list.js
@@ -4,10 +4,6 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 class W2DAttributeList extends SkeletonMixin(LitElement) {
 	static get styles() {
 		return [ super.styles, css`
-			:host {
-				height: 1rem;
-				overflow-y: hidden;
-			}
 			*,
 			::slotted(*) {
 				overflow: hidden;

--- a/features/workToDo/d2l-w2d-attribute-list.js
+++ b/features/workToDo/d2l-w2d-attribute-list.js
@@ -12,6 +12,7 @@ class W2DAttributeList extends SkeletonMixin(LitElement) {
 			::slotted(*) {
 				overflow: hidden;
 				white-space: nowrap;
+				text-overflow: ellipsis;
 			}
 		`];
 	}

--- a/features/workToDo/d2l-w2d-attribute-list.js
+++ b/features/workToDo/d2l-w2d-attribute-list.js
@@ -5,16 +5,11 @@ class W2DAttributeList extends SkeletonMixin(LitElement) {
 	static get styles() {
 		return [ super.styles, css`
 			:host {
-				display: flex;
-				flex-flow: row wrap;
 				height: 1rem;
 				overflow-y: hidden;
 			}
 			*,
 			::slotted(*) {
-				align-items: center;
-				display: flex;
-				flex-flow: row nowrap;
 				overflow: hidden;
 				white-space: nowrap;
 			}

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -92,14 +92,14 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 				height:18px;
 				width:18px;
 				vertical-align: top;
-				margin-right: 0.15rem;
+				margin-left: -0.15rem;
 			}
 			.d2l-w2d-list-item-attributes *:first-child::before {
 				content: "";
 				height: 0;
 				width: 0;
 				display: initial;
-				margin-right: 0;
+				margin-left: 0;
 			}
 		`];
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -149,8 +149,10 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 				<d2l-list-item-content>
 					<d2l-activity-name class="d2l-w2d-list-item-name" href="${this.href}" .token="${this.token}"></d2l-activity-name>
 					<d2l-w2d-attribute-list slot="secondary" class="d2l-w2d-list-item-attributes">
-						${ !this.collapsed ? startDate : null }
-						${this._renderAttributeListCollapsed()}
+						<div>
+							${ !this.collapsed ? startDate : null }
+							${this._renderAttributeListCollapsed()}
+						</div>
 					</d2l-w2d-attribute-list>
 					${ !this.collapsed ? html`<d2l-activity-description slot="supporting-info" href="${this.href}" .token="${this.token}"></d2l-activity-description>` : startDate}
 				</d2l-list-item-content>
@@ -169,10 +171,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 		const type = !this._isCourse ? lithtml`<d2l-activity-type href="${this.href}" .token="${this.token}"></d2l-activity-type>` : null;
 		const courseName = this._isCourse ? lithtml`<span>${this.localize('course')}</span>` : lithtml`<span>${this._parentName}</span>`;
 		return html`
-		<div>
-			${this.collapsed ? dueDate : type}<!--
-			-->${courseName}
-		</div>
+			${this.collapsed ? dueDate : type}${courseName}
 		`;
 	}
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -170,8 +170,8 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 		const courseName = this._isCourse ? lithtml`<span>${this.localize('course')}</span>` : lithtml`<span>${this._parentName}</span>`;
 		return html`
 		<div>
-			${this.collapsed ? dueDate : type}
-			${courseName}
+			${this.collapsed ? dueDate : type}<!--
+			-->${courseName}
 		</div>
 		`;
 	}

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -173,7 +173,8 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 		const type = !this._isCourse ? lithtml`<d2l-activity-type href="${this.href}" .token="${this.token}"></d2l-activity-type>` : null;
 		const courseName = this._isCourse ? lithtml`<span>${this.localize('course')}</span>` : lithtml`<span>${this._parentName}</span>`;
 		return html`
-			${this.collapsed ? dueDate : type}${courseName}
+			${this.collapsed ? dueDate : type}
+			${courseName}
 		`;
 	}
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -91,6 +91,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 				display: inline-block;
 				height:18px;
 				width:18px;
+				vertical-align: top;
 			}
 			.d2l-w2d-list-item-attributes *:first-child::before {
 				content: "";
@@ -162,13 +163,15 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 	_renderAttributeListCollapsed() {
 		let dueDate;
 		if (this._dates.due || this._dates.end) {
-			dueDate = lithtml`<div>${this._dates.due ? this.localize('dueWithDate', 'dueDate', formatDate(this._dates.due, {format: 'shortMonthDay'})) : this.localize('endWithDate', 'endDate', formatDate(this._dates.end, {format: 'shortMonthDay'}))}</div>`;
+			dueDate = lithtml`<span>${this._dates.due ? this.localize('dueWithDate', 'dueDate', formatDate(this._dates.due, {format: 'shortMonthDay'})) : this.localize('endWithDate', 'endDate', formatDate(this._dates.end, {format: 'shortMonthDay'}))}</span>`;
 		}
 		const type = !this._isCourse ? lithtml`<d2l-activity-type href="${this.href}" .token="${this.token}"></d2l-activity-type>` : null;
-		const courseName = this._isCourse ? lithtml`<div>${this.localize('course')}</div>` : lithtml`<div>${this._parentName}</div>`;
+		const courseName = this._isCourse ? lithtml`<span>${this.localize('course')}</span>` : lithtml`<span>${this._parentName}</span>`;
 		return html`
+		<div>
 			${this.collapsed ? dueDate : type}
 			${courseName}
+		</div>
 		`;
 	}
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -92,12 +92,14 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 				height:18px;
 				width:18px;
 				vertical-align: top;
+				margin-right: 0.15rem;
 			}
 			.d2l-w2d-list-item-attributes *:first-child::before {
 				content: "";
 				height: 0;
 				width: 0;
 				display: initial;
+				margin-right: 0;
 			}
 		`];
 

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -97,6 +97,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 				content: "";
 				height: 0;
 				width: 0;
+				display: initial;
 			}
 		`];
 


### PR DESCRIPTION
## Overview

 Before | After 
------- | ------
 ![image](https://user-images.githubusercontent.com/34746763/126525606-7e6379f2-b9d8-4d81-88d1-33baaf6c9c4f.png) | ![image](https://user-images.githubusercontent.com/34746763/126800728-a7ffbc64-98f5-4e53-b8d5-66ea2d7518fd.png)

Fix due date being cut off.

### Reason for change

See Ticket: [DE44196](https://rally1.rallydev.com/#/515253241784d/custom/367300408400?detail=%2Fdefect%2F602631407919&fdp=true?fdp=true): 1. Work To Do Widget Truncates Date for Long Course Names

### Changes summarized

- Remove Flex styling.
- Use `span` instead of `div` because these are now inline elements.
- Wrap all in a `div`.
- Add `text-overflow` property to slot.
- Add `vertical-align` property to bullet.
- Balance spacing on both sides of bullet.

### Suggested future tasks

None.

## Checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [ ] This isn't a 'quick-and-dirty' job