### PR TITLE
fix: Add caching to search and load more

### DIFF
--- a/components/activity/editor/collection/d2l-activity-editor-collection-add.js
+++ b/components/activity/editor/collection/d2l-activity-editor-collection-add.js
@@ -270,7 +270,7 @@ class ActivityEditorCollectionAdd extends HypermediaStateMixin(LocalizeCollectio
 	async _onLoadMoreClick() {
 		this._isLoadingMore = true;
 		try {
-			const summoned = await this._startAddExistingNext.summon();
+			const summoned = await this._startAddExistingNext.summon(undefined, true);
 			const newCandidates = this._addExtrasToCandidates(summoned.entities);
 			this._candidates.push(...newCandidates);
 			this._loadMoreFailed = false;
@@ -285,7 +285,7 @@ class ActivityEditorCollectionAdd extends HypermediaStateMixin(LocalizeCollectio
 		this._isLoadingCandidates = true;
 		const summoned = await this._startAddExistingSearch.summon({
 			collectionSearch: e.detail.value
-		});
+		}, true);
 		this._candidates = this._addExtrasToCandidates(summoned.entities);
 		this._isLoadingCandidates = false;
 	}

--- a/karma.sauce.conf.js
+++ b/karma.sauce.conf.js
@@ -28,6 +28,11 @@ const customLaunchers = {
 module.exports = config => {
 	config.set(
 		merge(createDefaultConfig(config), {
+			client: {
+				mocha: {
+					timeout : 6000 // 6 seconds - upped from 2 seconds
+				}
+			},
 			files: [
 				// runs all files ending with .test in the test folder,
 				// can be overwritten by passing a --grep flag. examples:


### PR DESCRIPTION
[DS11220](https://rally1.rallydev.com/#/357252966636d/dashboard?detail=%2Fdefectsuite%2F602692795579&fdp=true?fdp=true): Learning paths >20.21.5 >  Unable to add Activities to Learning Path

Small PR that will fix search's behavior in the activity collection editor.

Foundation engine caches entity responses based on the URL. Because this search provides its query through the body of the request, the URL is always the same, so you always get the same search results.

This change un-caches the results from search, such that the same URL will be able to provide different results when searching.

Since the Load More Summon Action's URLs have a small chance to also coincidentally be searched from, I uncached it as well to make sure we won't need to come back and change it in the future. Please note that Load more always returns the second page of empty search results regardless of caching due to existing issues in foundation engine - This PR will not address that.

There isn't a need to un-cache the initial load, so I left that last summon action alone.

Manually tested this on ArtemisDev with varying queries and workflows.