### PR TITLE
DE44473 Fix date changing behaviour

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -310,7 +310,7 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 
 		return html`
 			${this._renderSkeleton()}
-			${this._overdue.length === 0 && this._categories.length === 0 ? emptyList : lists}
+			${overdue.length === 0 && categories.length === 0 ? emptyList : lists}
 		`;
 	}
 

--- a/features/workToDo/w2dDateCategoryObserver.js
+++ b/features/workToDo/w2dDateCategoryObserver.js
@@ -52,7 +52,7 @@ export class W2dDateCategory extends SirenSubEntities {
 		if (!category) {
 			this._startDate = new Date(observer[startDate]);
 			this._groupByDays = observer[groupByDays];
-			if (this._sirenFacades) this.entities = this._sirenFacades;
+			this.entities = this._sirenFacades || [];
 		}
 
 		const filterByCategory = categoryMap => (category ? categoryMap.sirenFacadesByCategory[observer[category]] : categoryMap.categoryInfo);


### PR DESCRIPTION
When the `startDate` and `endDate` on the component changes, it should re-fetch W2D based on that new date range, and display the W2D items for that date range. This is useful for e.g. in BfP, where we only ever show two weeks at a time.

Previously, data would be re-fetched, but due to nothing necessarily being returned (i.e. no upcoming activities in the specified time range), we wouldn't necessarily replace the contents of `categories` with the new data. Instead, we were basically acting like _only_ the startDate was changing, and would show "W2D from your selected startDate until whatever endDate was when the widget was first created". This is incorrect, though - with both start and end date set, we should show _only_ W2D from that date range (grouped and paged as required).

The change here to always set `this._entities = this._sirenFacades || []` is the main fix. This way, if `_sirenFacades` gets updated to an empty array (or, in reality, is just un-set), then we correctly set `this.entities = []`.

The minor additional change here is using `overdue/categories` rather than `this._overdue/this._categories` to calculate whether or not to use the empty state. This isn't going to do anything in the vast majority of circumstances, but it's slightly more correct, as we e.g. we do run a filter on `categories` that could result in `categories.length != this._categories.length`, where the former is what we're actually displaying.

Tested this locally (and will try it out on a sitelord site as well) and didn't see any issues - listing, grouping, and paging continue to work as expected for main W2D widget, as the change here is basically a no-op for it (startDate/endDate are set once and only once for that use case).