### PR TITLE
DE44542 - Adds the option for activities that have not started yet to be clickable (needed for parent portal)

### DIFF
--- a/features/workToDo/d2l-w2d-collections.js
+++ b/features/workToDo/d2l-w2d-collections.js
@@ -30,7 +30,6 @@ const pageSize = Object.freeze({
 class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
-			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
 			currentTime: { type: String, attribute: 'current-time' },
 			collapsed: { type: Boolean },
 			groupByDays: { type: Number, attribute: 'group-by-days' },
@@ -42,6 +41,8 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 			upcomingWeekLimit: { type: String, attribute: 'upcoming-week-limit' },
 			skeleton: { type: Boolean, reflect: true },
 			userUrl: { type: String, attribute: 'user-url' },
+			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
+			clickableFutureActivities: { type: Boolean, attribute: 'clickable-future-activities' },
 			_categories: {
 				type: Array,
 				observable: observableTypes.custom,
@@ -257,7 +258,15 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 				if (limit === 0) return;
 				const list = html`
 					${this._renderHeader3(header, this._pagingTotalResultsOverdue)}
-					<d2l-w2d-list href="${category.href}" .token="${this.token}" category="${category.index}" ?collapsed="${this.collapsed}" limit="${ifDefined(limit)}" ?allow-unclickable-activities="${this.allowUnclickableActivities}"></d2l-w2d-list>
+					<d2l-w2d-list
+						href="${category.href}"
+						.token="${this.token}"
+						category="${category.index}"
+						?collapsed="${this.collapsed}"
+						limit="${ifDefined(limit)}"
+						?allow-unclickable-activities="${this.allowUnclickableActivities}"
+						?clickable-future-activities="${this.clickableFutureActivities}">
+					</d2l-w2d-list>
 				`;
 				limit = limit === undefined ? limit : Math.max(limit - category.count, 0);
 				return list;
@@ -276,7 +285,15 @@ class W2dCollections extends LocalizeDynamicMixin(HypermediaStateMixin(LitElemen
 				if (limit === 0) return;
 				const list = html`
 					${this._renderHeader3(header, this._pagingTotalResultsUpcoming)}
-					<d2l-w2d-list href="${category.href}" .token="${this.token}" category="${category.index}" ?collapsed="${this.collapsed}" limit="${ifDefined(limit)}" ?allow-unclickable-activities="${this.allowUnclickableActivities}"></d2l-w2d-list>
+					<d2l-w2d-list
+						href="${category.href}"
+						.token="${this.token}"
+						category="${category.index}"
+						?collapsed="${this.collapsed}"
+						limit="${ifDefined(limit)}"
+						?allow-unclickable-activities="${this.allowUnclickableActivities}"
+						?clickable-future-activities="${this.clickableFutureActivities}">
+					</d2l-w2d-list>
 				`;
 				limit = limit === undefined ? limit : Math.max(limit - category.count, 0);
 				return list;

--- a/features/workToDo/d2l-w2d-list-item.js
+++ b/features/workToDo/d2l-w2d-list-item.js
@@ -39,9 +39,10 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 
 	static get properties() {
 		return {
-			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
 			collapsed: { type: Boolean },
 			skeleton: { type: Boolean },
+			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
+			clickableFutureActivities: { type: Boolean, attribute: 'clickable-future-activities' },
 			_hasStarted: { type: Boolean, observable: observableTypes.classes, method: (classes) => classes.includes('started') },
 			_dates: {
 				type: Object,
@@ -121,7 +122,7 @@ class W2DListItemMixin extends HypermediaStateMixin(ListItemLinkMixin(LocalizeDy
 	}
 
 	get actionHref() {
-		return ((this._dates && !this._dates.start) || this._hasStarted) ? this._actionHref : undefined;
+		return (this.clickableFutureActivities || (this._dates && !this._dates.start) || this._hasStarted) ? this._actionHref : undefined;
 	}
 
 	set actionHref(href) {

--- a/features/workToDo/d2l-w2d-list.js
+++ b/features/workToDo/d2l-w2d-list.js
@@ -46,13 +46,7 @@ class W2dList extends HypermediaStateMixin(LitElement) {
 		return html`
 			<d2l-list separators="${this.collapsed ? 'none' : 'all'}">
 				${activities.map(activity => html`
-					<d2l-w2d-list-item
-						href="${activity.href}"
-						.token="${this.token}"
-						?collapsed="${this.collapsed}"
-						?allow-unclickable-activities="${this.allowUnclickableActivities}"
-						?clickable-future-activities="${this.clickableFutureActivities}">
-					</d2l-w2d-list-item>
+					<d2l-w2d-list-item href="${activity.href}" .token="${this.token}" ?collapsed="${this.collapsed}" ?allow-unclickable-activities="${this.allowUnclickableActivities}" ?clickable-future-activities="${this.clickableFutureActivities}"></d2l-w2d-list-item>
 				`)}
 			</d2l-list>
 		`;

--- a/features/workToDo/d2l-w2d-list.js
+++ b/features/workToDo/d2l-w2d-list.js
@@ -14,11 +14,12 @@ const rel = Object.freeze({
 class W2dList extends HypermediaStateMixin(LitElement) {
 	static get properties() {
 		return {
-			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
 			category: { type: String },
 			collapsed: { type: Boolean },
 			limit: { type: Number },
 			skeleton: { type: Boolean},
+			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
+			clickableFutureActivities: { type: Boolean, attribute: 'clickable-future-activities' },
 			_activities: {
 				type: Array,
 				observable: observableTypes.custom,
@@ -45,7 +46,13 @@ class W2dList extends HypermediaStateMixin(LitElement) {
 		return html`
 			<d2l-list separators="${this.collapsed ? 'none' : 'all'}">
 				${activities.map(activity => html`
-					<d2l-w2d-list-item href="${activity.href}" .token="${this.token}" ?collapsed="${this.collapsed}" ?allow-unclickable-activities="${this.allowUnclickableActivities}"></d2l-w2d-list-item>
+					<d2l-w2d-list-item
+						href="${activity.href}"
+						.token="${this.token}"
+						?collapsed="${this.collapsed}"
+						?allow-unclickable-activities="${this.allowUnclickableActivities}"
+						?clickable-future-activities="${this.clickableFutureActivities}">
+					</d2l-w2d-list-item>
 				`)}
 			</d2l-list>
 		`;

--- a/features/workToDo/d2l-w2d-work-to-do.js
+++ b/features/workToDo/d2l-w2d-work-to-do.js
@@ -21,7 +21,6 @@ const rel = Object.freeze({
 class w2dWorkToDo extends LocalizeDynamicMixin(HypermediaStateMixin(LitElement)) {
 	static get properties() {
 		return {
-			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
 			currentTime: { type: String, attribute: 'current-time' },
 			collapsed: { type: Boolean },
 			dataFullPagePath: { type: String, attribute: 'data-full-page-path' },
@@ -31,6 +30,8 @@ class w2dWorkToDo extends LocalizeDynamicMixin(HypermediaStateMixin(LitElement))
 			endDate: { type: String, attribute: 'end-date' },
 			overdueWeekLimit: { type: Number, attribute: 'data-overdue-week-limit' },
 			upcomingWeekLimit: { type: String, attribute: 'data-upcoming-week-limit' },
+			allowUnclickableActivities: { type: Boolean, attribute: 'allow-unclickable-activities' },
+			clickableFutureActivities: { type: Boolean, attribute: 'clickable-future-activities' },
 			_myActivitiesHref: { type: String, observable: observableTypes.link, rel: rel.myActivities, prime: true },
 			_myOrganizationActivitiesHref: { type: String, observable: observableTypes.link, rel: rel.myOrganizationActivities, prime: true },
 			_organizationHompage: { type: String, observable: observableTypes.link, rel: rel.organizationHomepage },
@@ -129,7 +130,8 @@ class w2dWorkToDo extends LocalizeDynamicMixin(HypermediaStateMixin(LitElement))
 				upcoming-week-limit="${this.upcomingWeekLimit}"
 				?skeleton="${!this._loaded}"
 				user-url="${this.href}"
-				?allow-unclickable-activities="${this.allowUnclickableActivities}"></d2l-w2d-collections>
+				?allow-unclickable-activities="${this.allowUnclickableActivities}"
+				?clickable-future-activities="${this.clickableFutureActivities}"></d2l-w2d-collections>
 		`;
 	}
 


### PR DESCRIPTION
# Description
Parent portal needs activities that haven't started yet to still be clickable to I've added an option to do that

# Rally
https://rally1.rallydev.com/#/378960033600d/workviews?Name=%5BBfP%5D%20Activities%20that%20haven't%20started%20yet%20aren't%20clickable&Priority=Normal&Project=https%3A%2F%2Frally1.rallydev.com%2Fslm%2Fwebservice%2Fv2.x%2Fproject%2F378960033600&Severity=Minor%20Problem&detail=%2Fdefect%2F605126742893&iteration=u&rankTo=BOTTOM&view=dd31669c-8a70-406a-8edf-892fc6f74aef&fdp=true?fdp=true