### PR TITLE
Update the UI to send the canSetRegister flag

### DIFF
--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -121,14 +121,15 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 
 	_onCheckboxChange(e) {
 		const checked = e.detail.checked;
-		if (checked && this._rules.length) {
+		if (checked) {
 			// when the user re-checks the box, re-commit the entitlement
 			this._onRulesChanged();
 		} else {
 			if (!this._hasAction('_createEntitlement')) return;
 			// when the user unchecks the box, delete the entitlement, but don't update the rules
 			this._createEntitlement.commit({
-				rules: []
+				rules: [],
+				canSelfRegister: false
 			});
 		}
 		// create a composed event so that we can catch it in the LMS
@@ -150,12 +151,6 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 
 	_onRuleDeleted(e) {
 		this._rules.splice(e.target.ruleIndex, 1);
-		this._state.updateProperties({
-			_rules: { observable: observableTypes.subEntities, rel: rels.rule, route: [
-				{ observable: observableTypes.link, rel: rels.entitlementRules }
-			], value: this._rules }
-		});
-
 		this.requestUpdate();
 		// call it manually
 		this._onRulesChanged();
@@ -168,14 +163,16 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 
 	_onRulesChanged() {
 		if (!this._hasAction('_createEntitlement')) return;
-
 		const message = this._rules.map(rule => {
 			const ruleObj = {};
 			rule.entities.forEach(condition => ruleObj[condition.properties.type] = condition.properties.values);
 			return ruleObj;
 		});
+
+		// canSelfRegister should only be true when there are no rules and the checkbox is checked.
 		this._createEntitlement.commit({
-			rules: message
+			rules: message,
+			canSelfRegister: this._rules.length === 0
 		});
 	}
 

--- a/features/discover/test/d2l-discover-rules.test.js
+++ b/features/discover/test/d2l-discover-rules.test.js
@@ -119,7 +119,8 @@ describe('d2l-discover-rules', () => {
 			await listener;
 			await el.updateComplete;
 			const expectedCommit = {
-				rules: []
+				rules: [],
+				canSelfRegister: false
 			};
 			expect(commitSpy.calledOnce, 'commit was not called').to.be.true;
 			expect(commitSpy.calledWith(expectedCommit), `commit was not called with: ${expectedCommit}`).to.be.true;
@@ -137,7 +138,8 @@ describe('d2l-discover-rules', () => {
 			await el.updateComplete;
 			expect(el._rules).to.be.empty;
 			const expectedCommit = {
-				rules: []
+				rules: [],
+				canSelfRegister: true
 			};
 			expect(commitSpy.calledOnce, 'commit was not called').to.be.true;
 			expect(commitSpy.calledWith(expectedCommit), `commit was not called with: ${expectedCommit}`).to.be.true;
@@ -185,7 +187,8 @@ describe('d2l-discover-rules', () => {
 				rules: [
 					{ fruit: ['apple', 'orange'] },
 					{ entree: ['spaghetti'], dessert: ['cake', 'pie'] }
-				]
+				],
+				canSelfRegister: false
 			};
 
 			expect(commitSpy.calledOnce, 'commit was not called').to.be.true;

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@brightspace-ui/intl": "^3.5.0",
     "d2l-course-image": "github:Brightspace/course-image#semver:^3",
     "d2l-navigation": "github:BrightspaceUI/navigation#semver:^4",
+    "d2l-users": "github:BrightspaceHypermediaComponents/users#semver:^2",
     "lit-element": "^2",
     "lit-html": "^1.3.0",
     "siren-parser": "^8.2.0"


### PR DESCRIPTION
Small change to send an additional flag to the BFF when committing for determining the checkbox state. 
Edited the tests to confirm the flag is being set correctly for different values.