### PR TITLE
DE44655 Handle closing quiz item dialog on cancel

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -80,6 +80,8 @@ const componentClass = class extends HypermediaStateMixin(ListItemButtonMixin(Li
 
 		// Save or Cancel button Handler
 		delayedResult.AddListener((activities) => {
+			if (!activities) return; // Cancel
+
 			// Trigger Section child to refresh name
 			++this._refreshCounter;
 			const activityHrefs = activities.map(activity => activity.href);


### PR DESCRIPTION
The dialog callback `activities` param is `undefined` if no questions were updated/saved, so we can return from the callback without performing any updates. Calling `activities.map` was throwing errors when cancelling the dialog.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fdefect%2F605845103195