### PR TITLE
fix: Get resolved token for simple components

### DIFF
--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -21,7 +21,7 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 			isSelfEnrollable: { type: Boolean, observable: observableTypes.classes,
 				method: (classes) => classes.includes(rels.selfAssignableClass),
 				route: [{observable: observableTypes.link, rel: rels.organization }] },
-			_resolvedToken: {type: String },
+			_resolvedToken: { type: String },
 			_rules: { type: Array },
 			_ruleIndex: { type: Number },
 			_dialogOpened: { type: Boolean },

--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -21,6 +21,7 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 			isSelfEnrollable: { type: Boolean, observable: observableTypes.classes,
 				method: (classes) => classes.includes(rels.selfAssignableClass),
 				route: [{observable: observableTypes.link, rel: rels.organization }] },
+			_resolvedToken: {type: String },
 			_rules: { type: Array },
 			_ruleIndex: { type: Number },
 			_dialogOpened: { type: Boolean },
@@ -72,9 +73,9 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 				<!-- rules cards -->
 				${this._rules.map((rule, index) => html`
 					<d2l-discover-rule-card
-						.token="${this.token}"
 						.rule="${rule}"
 						.ruleIndex="${index}"
+						token="${this._resolvedToken}"
 						@d2l-rule-delete-click="${this._onRuleDeleted}"
 						@d2l-rule-edit-click="${this._onRuleEdit}"></d2l-discover-rule-card>
 				`)}
@@ -103,6 +104,9 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 
 		if (changedProperties.has('_getEntitlement')) {
 			this._summonEntitlement();
+		}
+		if (changedProperties.has('token')) {
+			this._tokenChanged();
 		}
 	}
 
@@ -165,10 +169,9 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 		if (!this._hasAction('_createEntitlement')) return;
 		const message = this._rules.map(rule => {
 			const ruleObj = {};
-			rule.entities.forEach(condition => ruleObj[condition.properties.type] = condition.properties.values);
+			rule.entities.forEach(condition => ruleObj[condition.properties.id] = condition.properties.values);
 			return ruleObj;
 		});
-
 		// canSelfRegister should only be true when there are no rules and the checkbox is checked.
 		this._createEntitlement.commit({
 			rules: message,
@@ -213,5 +216,12 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 		}
 	}
 
+	//Retrieves a token for interacting with the BFF
+	async _tokenChanged() {
+		const resolvedToken = await this.token();
+		if (resolvedToken) {
+			this._resolvedToken = resolvedToken;
+		}
+	}
 }
 customElements.define('d2l-discover-rules', EntitlementRules);

--- a/features/discover/lang/en-us.js
+++ b/features/discover/lang/en-us.js
@@ -17,6 +17,7 @@ export default {
 	"text-edit": "Edit", // Title for edit menu item
 	"text-remove-condition": "Remove condition {conditionType}", // Screenreader text when removing a condition from a rule
 	"text-rule-matches": "Rule matches {count} users", // Information about how many users a rule matches
+	"text-rule-matches-card": "Matches {count} users", // Information about how many users a rule matches on a card
 	"text-rules-description": "To self-enroll in this course, users must match one or more of these rules.", // description for enrollment rules
 	"text-rules": "Enrollment Rules", // title for enrollment rules options
 	"text-select-conditions": "Select Conditions", // header text for selecting the set of conditions for a rule

--- a/features/discover/test/d2l-discover-rules.test.js
+++ b/features/discover/test/d2l-discover-rules.test.js
@@ -44,7 +44,7 @@ const entitlementEntity = {
 	entities: [
 		{
 			entities: [
-				{ properties: { type: 'fruit', values: ['apple', 'orange'] }, rel: [rels.condition] }
+				{ properties: { id: '_fruit', type: 'fruit', values: ['apple', 'orange'] }, rel: [rels.condition] }
 			],
 			rel: [rels.rule]
 		}
@@ -56,8 +56,8 @@ const entitlementEntity = {
 };
 const conditionTypesEntity = {
 	entities: [
-		{ rel: [rels.conditionType], properties: { type: 'fruit' } },
-		{ rel: [rels.conditionType], properties: { type: 'entree' } }
+		{ rel: [rels.conditionType], properties: { id: '_fruit', type: 'fruit' } },
+		{ rel: [rels.conditionType], properties: { id: '_entree', type: 'entree' } }
 	],
 	links: [
 		{ rel: ['self'], href: conditionTypesHref }
@@ -176,8 +176,8 @@ describe('d2l-discover-rules', () => {
 
 			const rulePicker = dialog.shadowRoot.querySelector('d2l-discover-rule-picker');
 			const rule = [
-				{ properties: { type: 'entree', values: ['spaghetti'] } },
-				{ properties: { type: 'dessert', values: ['cake', 'pie'] } }
+				{ properties: { id:'_entree', type: 'entree', values: ['spaghetti'] } },
+				{ properties: { id:'_dessert', type: 'dessert', values: ['cake', 'pie'] } }
 			];
 			rulePicker.conditions = rule;
 			// click done
@@ -185,8 +185,8 @@ describe('d2l-discover-rules', () => {
 			await el.updateComplete;
 			const expectedCommit = {
 				rules: [
-					{ fruit: ['apple', 'orange'] },
-					{ entree: ['spaghetti'], dessert: ['cake', 'pie'] }
+					{ _fruit: ['apple', 'orange'] },
+					{ _entree: ['spaghetti'], _dessert: ['cake', 'pie'] }
 				],
 				canSelfRegister: false
 			};


### PR DESCRIPTION
Small fixes for enrollment rules UI: 

- Gets the resolved token and passes it to the non-hmc component `d2l-discover-rule-card` so it has a proper token
- Changes the enrollment rules commit to use the `id` instead of the `type` during rule generation
- Updates tests