### PR TITLE
feat: US126725 Add read only rule list

### DIFF
--- a/features/discover/d2l-discover-rule-list.js
+++ b/features/discover/d2l-discover-rule-list.js
@@ -11,13 +11,12 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
-// there is a bug in the engine so this is a dumb component instead of a hypermedia one
+//Simple list for displaying non-interactable rules
 class RuleList extends LocalizeDynamicMixin(RtlMixin(LitElement)) {
 	static get properties() {
 		return {
 			rules: { type: Array },
 			token: { type: String },
-			_titles: { type: Array },
 		};
 	}
 
@@ -31,30 +30,11 @@ class RuleList extends LocalizeDynamicMixin(RtlMixin(LitElement)) {
 				margin: 0.4rem 0 0.4rem 0.8rem;
 			}
 
-			.d2l-rule-card-title {
+			.d2l-rule-list-title {
 				color: var(--d2l-color-ferrite);
 				font-weight: 600;
 				font-size: 0.8rem;
 				margin-bottom: 0.8rem;
-			}
-
-			.d2l-rule-card-profiles {
-				border: 1px solid black;
-				display: inline-block;
-				margin-right: 16px;
-			}
-
-			.d2l-rule-card-match-users {
-				font-size: 0.7rem;
-				font-weight: 300;
-				color: var(--d2l-color-tungsten);
-				display: inline-block;
-			}
-			d2l-dropdown-context-menu {
-				margin: -0.3rem -0.3rem 0 0;
-			}
-			d2l-dropdown-menu {
-				margin-top: -0.3rem;
 			}
 		`;
 	}
@@ -71,31 +51,13 @@ class RuleList extends LocalizeDynamicMixin(RtlMixin(LitElement)) {
 				${this.rules.map((rule) => html`
 					<d2l-list-item class="d2l-rule-list-item">
 						<div class="d2l-rule-list-item-content">
-							<div class="d2l-rule-card-title">${this._getTitle(rule)}</div>
+							<div class="d2l-rule-list-title">${this._getTitle(rule)}</div>
 							<d2l-discover-rule-card-match-info token="${this.token}" .rule="${rule}"></d2l-discover-rule-card-match-info>
 						</div>
 					</d2l-list-item>
 				`)}
 			</d2l-list>
 		`;
-	}
-
-	updated(changedProperties) {
-		super.updated(changedProperties);
-	}
-
-	_onDeleteClick() {
-		const event = new CustomEvent('d2l-rule-delete-click', {
-			bubbles: true
-		});
-		this.dispatchEvent(event);
-	}
-
-	_onEditClick() {
-		const event = new CustomEvent('d2l-rule-edit-click', {
-			bubbles: true
-		});
-		this.dispatchEvent(event);
 	}
 
 	_getTitle(rule) {

--- a/features/discover/d2l-discover-rule-list.js
+++ b/features/discover/d2l-discover-rule-list.js
@@ -1,0 +1,123 @@
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-context-menu.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
+import '@brightspace-ui/core/components/list/list.js';
+import '@brightspace-ui/core/components/list/list-item.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
+import './d2l-discover-rule-picker-dialog.js';
+import './d2l-discover-rule-card-match-info.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+
+// there is a bug in the engine so this is a dumb component instead of a hypermedia one
+class RuleList extends LocalizeDynamicMixin(RtlMixin(LitElement)) {
+	static get properties() {
+		return {
+			rules: { type: Array },
+			token: { type: String },
+			_titles: { type: Array },
+		};
+	}
+
+	static get styles() {
+		return css`
+			.d2l-rule-list-item {
+				max-width: 25rem;
+			}
+
+			.d2l-rule-list-item-content {
+				margin: 0.4rem 0 0.4rem 0.8rem;
+			}
+
+			.d2l-rule-card-title {
+				color: var(--d2l-color-ferrite);
+				font-weight: 600;
+				font-size: 0.8rem;
+				margin-bottom: 0.8rem;
+			}
+
+			.d2l-rule-card-profiles {
+				border: 1px solid black;
+				display: inline-block;
+				margin-right: 16px;
+			}
+
+			.d2l-rule-card-match-users {
+				font-size: 0.7rem;
+				font-weight: 300;
+				color: var(--d2l-color-tungsten);
+				display: inline-block;
+			}
+			d2l-dropdown-context-menu {
+				margin: -0.3rem -0.3rem 0 0;
+			}
+			d2l-dropdown-menu {
+				margin-top: -0.3rem;
+			}
+		`;
+	}
+
+	static get localizeConfig() {
+		return {
+			importFunc: async lang => (await import(`./lang/${lang}.js`)).default
+		};
+	}
+
+	render() {
+		return html`
+			<d2l-list>
+				${this.rules.map((rule) => html`
+					<d2l-list-item class="d2l-rule-list-item">
+						<div class="d2l-rule-list-item-content">
+							<div class="d2l-rule-card-title">${this._getTitle(rule)}</div>
+							<d2l-discover-rule-card-match-info token="${this.token}" .rule="${rule}"></d2l-discover-rule-card-match-info>
+						</div>
+					</d2l-list-item>
+				`)}
+			</d2l-list>
+		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+	}
+
+	_onDeleteClick() {
+		const event = new CustomEvent('d2l-rule-delete-click', {
+			bubbles: true
+		});
+		this.dispatchEvent(event);
+	}
+
+	_onEditClick() {
+		const event = new CustomEvent('d2l-rule-edit-click', {
+			bubbles: true
+		});
+		this.dispatchEvent(event);
+	}
+
+	_getTitle(rule) {
+		const conditions = rule.entities;
+		let title = '';
+		for (let i = 0; i < conditions.length; i++) {
+			const condition = conditions[i];
+			title += `${condition.properties.type}: `;
+			const attrList = condition.properties.values;
+			for (let j = 0; j < attrList.length; j++) {
+				const attr = attrList[j];
+				title += attr;
+				if (j !== attrList.length - 1) {
+					title += ', ';
+				}
+			}
+			if (i !== conditions.length - 1) {
+				title += ' & ';
+			}
+		}
+		return title;
+	}
+}
+
+customElements.define('d2l-discover-rule-list', RuleList);

--- a/features/discover/d2l-discover-rules.js
+++ b/features/discover/d2l-discover-rules.js
@@ -75,10 +75,7 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 				<h5 class="d2l-body-small"><strong>${this.localize('text-rules')}</strong></h5>
 				<p>${this.localize('text-rules-description')}</p>
 				<!-- rules cards -->
-				${this.readOnly ?
-					this.renderReadOnlyRules() :
-					this.renderInteractibleRules()
-				}
+				${this.readOnly ? this._renderReadOnlyRules() : this._renderInteractibleRules()}
 			</div>
 			` : null}
 			${!this.readOnly ? html`
@@ -96,30 +93,8 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 					@d2l-dialog-close="${this._onDialogClose}"
 					@d2l-rules-changed="${this._onRulesChanged}"
 				></d2l-discover-rule-picker-dialog>
-				</d2l-labs-checkbox-drawer> ` : null
-			}
-		`;
-	}
-
-	renderReadOnlyRules() {
-		return html`
-			<d2l-discover-rule-list
-				.rules="${this._rules}"
-				token="${this._resolvedToken}">
-			</d2l-discover-rule-list>`;
-	}
-
-	renderInteractibleRules() {
-		return html`
-		${this._rules.map((rule, index) => html`
-			<d2l-discover-rule-card
-				.rule="${rule}"
-				.ruleIndex="${index}"
-				token="${this._resolvedToken}"
-				@d2l-rule-delete-click="${this._onRuleDeleted}"
-				@d2l-rule-edit-click="${this._onRuleEdit}">
-			</d2l-discover-rule-card>
-		`)}`
+				</d2l-labs-checkbox-drawer> ` : null }
+			`;
 	}
 
 	updated(changedProperties) {
@@ -205,6 +180,27 @@ class EntitlementRules extends LocalizeDynamicMixin(SkeletonMixin(HypermediaStat
 			const obj = this.shadowRoot.querySelector('d2l-discover-rule-list');
 			obj?.requestUpdate();
 		}
+	}
+
+	_renderInteractibleRules() {
+		return html`
+		${this._rules.map((rule, index) => html`
+			<d2l-discover-rule-card
+				.rule="${rule}"
+				.ruleIndex="${index}"
+				token="${this._resolvedToken}"
+				@d2l-rule-delete-click="${this._onRuleDeleted}"
+				@d2l-rule-edit-click="${this._onRuleEdit}">
+			</d2l-discover-rule-card>
+		`)}`;
+	}
+
+	_renderReadOnlyRules() {
+		return html`
+			<d2l-discover-rule-list
+				.rules="${this._rules}"
+				token="${this._resolvedToken}">
+			</d2l-discover-rule-list>`;
 	}
 
 	/**

--- a/features/discover/demo/d2l-discover-rules.html
+++ b/features/discover/demo/d2l-discover-rules.html
@@ -23,6 +23,11 @@
 			<d2l-demo-snippet>
 				<d2l-discover-rules href="./course-bff-2.json" token="cake"></d2l-discover-rules>
 			</d2l-demo-snippet>
+
+			<h2>d2l-discover-rules readonly</h2>
+			<d2l-demo-snippet>
+				<d2l-discover-rules href="./course-bff-2.json" token="cake" read-only></d2l-discover-rules>
+			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>
 </html>


### PR DESCRIPTION
[US126725](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fuserstory%2F519351532148&fdp=true?fdp=true): Discover UI -  Read-only state in the Discover Control Component

Builds the read-only state into the discover rule picker.
Adds a simple new list component for rendering these rules in read only mode, instead of within the interactable cards.

![image](https://user-images.githubusercontent.com/55998273/131697879-135b242a-c797-489f-b4c2-b15eae353fe6.png)
