### PR TITLE
US131490 Remove add-to-collection logic for importing sketchpad questions

### DIFF
--- a/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
+++ b/components/activity/editor/collection/custom/quiz/d2l-activity-collection-item-quiz.js
@@ -82,18 +82,22 @@ const componentClass = class extends HypermediaStateMixin(ListItemButtonMixin(Li
 
 		// Save or Cancel button Handler
 		delayedResult.AddListener((activities) => {
-			if (!activities) return; // Cancel
-
 			// Trigger Section child to refresh name
 			++this._refreshCounter;
-			const activityHrefs = activities.map(activity => activity.href);
+
 			fetch(this._state, true).then(() => {
 				// refresh Total Quiz Points
-				this.dispatchEvent(new CustomEvent('d2l-question-updated', {
+				const eventInit = {
 					bubbles: true,
-					composed: true,
-					detail: { activities: activityHrefs }
-				}));
+					composed: true
+				};
+
+				if (activities && activities.length) {
+					const activityHrefs = activities.map(activity => activity.href);
+					eventInit.detail = { activities: activityHrefs };
+				}
+
+				this.dispatchEvent(new CustomEvent('d2l-question-updated', eventInit));
 			});
 		});
 	}


### PR DESCRIPTION
New question objects (incl sections and pools) are added directly through QED.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F608666591373

Alongside [d2l-activities PR](https://github.com/BrightspaceHypermediaComponents/activities/pull/1978) and [LMS PR](https://github.com/Brightspace/lms/pull/14093).