### PR TITLE
fix: remove #empty in worktodo activities rel to make use of cache 

### DIFF
--- a/features/workToDo/d2l-w2d-work-to-do.js
+++ b/features/workToDo/d2l-w2d-work-to-do.js
@@ -10,7 +10,7 @@ import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynam
 import { telemetry } from './d2l-w2d-telemetry';
 
 const rel = Object.freeze({
-	myActivities: 'https://activities.api.brightspace.com/rels/my-activities#empty',
+	myActivities: 'https://activities.api.brightspace.com/rels/my-activities',
 	myOrganizationActivities: 'https://activities.api.brightspace.com/rels/my-organization-activities#empty',
 	organization: 'https://api.brightspace.com/rels/organization',
 	organizationHomepage: 'https://api.brightspace.com/rels/organization-homepage',

--- a/test/data/workToDo.js
+++ b/test/data/workToDo.js
@@ -10,7 +10,7 @@ export const workToDoMain = {
 	links: [
 		{
 			rel: [
-				'https://activities.api.brightspace.com/rels/my-activities#empty',
+				'https://activities.api.brightspace.com/rels/my-activities',
 			],
 			href: '/w2d-activities',
 		},


### PR DESCRIPTION
With this change, the intitial request to the LMS will return data. But more importantly, the activities will be cached, so that the second requests to both activities and overdue api don't need to both calculate all activities.

This roughly halves the work that the worktodo widget does on the LMS end.