### PR TITLE
Data correctly displays OrgUnitID

### DIFF
--- a/features/discover/d2l-discover-rule-picker.js
+++ b/features/discover/d2l-discover-rule-picker.js
@@ -268,7 +268,7 @@ class RulePicker extends MatchCountMixin(LocalizeDynamicMixin(HypermediaStateMix
 						value="${condition.properties.type}"
 						@change="${this._onConditionSelectChange}">
 						${this._conditionTypes ? this._conditionTypes.map(conditionType => html`
-							<option value="${conditionType.properties.type}" ?selected="${condition.properties.type === conditionType.properties.type}">${conditionType.properties.type}</option>
+							<option value="${conditionType.properties.type}" .selected="${condition.properties.type === conditionType.properties.type}">${conditionType.properties.type}</option>
 						`) : null}
 					</select>
 					<div class="d2l-picker-rule-separator d2l-body-compact">


### PR DESCRIPTION
[DE45032](https://rally1.rallydev.com/#/357252275780d/dashboard?detail=%2Fdefect%2F608078291677)

Switching the property binding from `?selected="${condition.properties.type === conditionType.properties.type}"` to `.selected="${condition.properties.type === conditionType.properties.type}"` reacts the way the AC wants it to.