### PR TITLE
fix: Fix how the open as external button looks when description is displayed

### DIFF
--- a/features/lti/d2l-lti-activity.js
+++ b/features/lti/d2l-lti-activity.js
@@ -142,6 +142,7 @@ class LtiActivity extends SkeletonMixin(LocalizeLtiActivityMixin(LabelMixin(Hype
 			.spanning-button {
 				width: 100%;
 				margin: 1rem 0rem 1.2rem 0rem;
+				display: block;
 			}
 			.subtle-button {
 				margin: 0.6rem 0rem;


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/14891041/134538112-c04fad88-d383-4263-843f-83542136dd6b.png)


After
![image](https://user-images.githubusercontent.com/14891041/134537969-1036b397-39a6-48df-a4b6-7528ce51ade6.png)
